### PR TITLE
Add Travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: cpp
+
+addons:
+  apt:
+    packages:
+    - doxygen
+
+script:
+  - mkdir build && pushd build
+  - ../configure --prefix=$HOME/.local
+  - make lib -j2
+  - make
+  - make install
+  


### PR DESCRIPTION
Allows to check further commits and pull requests
Travis continuous integration service must be enabled from repository settings
