### PR TITLE
fix dll install directory

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -29,6 +29,7 @@ BK_DEPS = @BK_DEPS@
 srcdir = @srcdir@
 top_builddir = @top_builddir@
 libdir = @libdir@
+dlldir = @dlldir@
 DLLPREFIX = @DLLPREFIX@
 LIBS = @LIBS@
 AR = @AR@
@@ -266,13 +267,14 @@ distclean: clean
 
 @COND_SHARED_1@install_muParser_dll: $(__muParser_dll___depname)
 @COND_SHARED_1@	$(INSTALL_DIR) $(DESTDIR)$(libdir)
+@COND_SHARED_1@	$(INSTALL_DIR) $(DESTDIR)$(dlldir)
 @COND_SHARED_1@	$(INSTALL_DATA) $(top_builddir)/lib/$(LIBPREFIX)muparser$(DEBUG_BUILD_POSTFIX).$(DLLIMP_SUFFIX) $(DESTDIR)$(libdir)
-@COND_SHARED_1@	$(INSTALL_PROGRAM) $(top_builddir)/lib/$(DLLPREFIX)muparser$(DEBUG_BUILD_POSTFIX)$(__muParser_dll___targetsuf3) $(DESTDIR)$(libdir)
+@COND_SHARED_1@	$(INSTALL_PROGRAM) $(top_builddir)/lib/$(DLLPREFIX)muparser$(DEBUG_BUILD_POSTFIX)$(__muParser_dll___targetsuf3) $(DESTDIR)$(dlldir)
 @COND_SHARED_1@	(cd $(DESTDIR)$(libdir) ; $(__muParser_dll___so_symlinks_inst_cmd))
 
 @COND_SHARED_1@uninstall_muParser_dll: 
 @COND_SHARED_1@	rm -f $(DESTDIR)$(libdir)/$(LIBPREFIX)muparser$(DEBUG_BUILD_POSTFIX).$(DLLIMP_SUFFIX)
-@COND_SHARED_1@	rm -f $(DESTDIR)$(libdir)/$(DLLPREFIX)muparser$(DEBUG_BUILD_POSTFIX)$(__muParser_dll___targetsuf3)
+@COND_SHARED_1@	rm -f $(DESTDIR)$(dlldir)/$(DLLPREFIX)muparser$(DEBUG_BUILD_POSTFIX)$(__muParser_dll___targetsuf3)
 @COND_SHARED_1@	(cd $(DESTDIR)$(libdir) ; $(__muParser_dll___so_symlinks_uninst_cmd))
 
 @COND_SHARED_1@install_muParser_dll_headers: 


### PR DESCRIPTION
`./configure` determines the correct `ddldir` for windows builds so use it in `Makefile.in`
