### PR TITLE
Fix potential buffer overflow

### DIFF
--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -192,7 +192,7 @@ API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
         muParser_t* const p(AsParser(a_hParser));
 
 #ifndef _UNICODE
-    sprintf(s_tmpOutBuf, "%s", p->GetVersion().c_str());
+    snprintf(s_tmpOutBuf, 2048, "%s", p->GetVersion().c_str());
 #else
     wsprintf(s_tmpOutBuf, _T("%s"), p->GetVersion().c_str());
 #endif
@@ -670,7 +670,7 @@ API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    sprintf(s_tmpOutBuf, "%s", p->GetExpr().c_str());
+    snprintf(s_tmpOutBuf, 2048, "%s", p->GetExpr().c_str());
 #else
     wsprintf(s_tmpOutBuf, _T("%s"), p->GetExpr().c_str());
 #endif
@@ -1033,7 +1033,7 @@ API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    sprintf(s_tmpOutBuf, "%s", pMsg);
+    snprintf(s_tmpOutBuf, 2048, "%s", pMsg);
 #else
     wsprintf(s_tmpOutBuf, _T("%s"), pMsg);
 #endif
@@ -1052,7 +1052,7 @@ API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    sprintf(s_tmpOutBuf, "%s", pToken);
+    snprintf(s_tmpOutBuf, 2048, "%s", pToken);
 #else
     wsprintf(s_tmpOutBuf, _T("%s"), pToken);
 #endif

--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -194,7 +194,7 @@ API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
 #ifndef _UNICODE
     snprintf(s_tmpOutBuf, 2048, "%s", p->GetVersion().c_str());
 #else
-    wsprintf(s_tmpOutBuf, _T("%s"), p->GetVersion().c_str());
+    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), p->GetVersion().c_str());
 #endif
 
     return s_tmpOutBuf;
@@ -672,7 +672,7 @@ API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
 #ifndef _UNICODE
     snprintf(s_tmpOutBuf, 2048, "%s", p->GetExpr().c_str());
 #else
-    wsprintf(s_tmpOutBuf, _T("%s"), p->GetExpr().c_str());
+    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), p->GetExpr().c_str());
 #endif
 
     return s_tmpOutBuf;
@@ -1035,7 +1035,7 @@ API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
 #ifndef _UNICODE
     snprintf(s_tmpOutBuf, 2048, "%s", pMsg);
 #else
-    wsprintf(s_tmpOutBuf, _T("%s"), pMsg);
+    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), pMsg);
 #endif
 
     return s_tmpOutBuf;
@@ -1054,7 +1054,7 @@ API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
 #ifndef _UNICODE
     snprintf(s_tmpOutBuf, 2048, "%s", pToken);
 #else
-    wsprintf(s_tmpOutBuf, _T("%s"), pToken);
+    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), pToken);
 #endif
 
     return s_tmpOutBuf;

--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -99,8 +99,8 @@ private:
     int m_nParserType;
 };
 
-const int MAX_BUF = 2048;
-static muChar_t s_tmpOutBuf[MAX_BUF];
+const int MaxBuf = 2048;
+static muChar_t s_tmpOutBuf[MaxBuf];
 
 //---------------------------------------------------------------------------
 //
@@ -193,9 +193,9 @@ API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
         muParser_t* const p(AsParser(a_hParser));
 
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, MAX_BUF, "%s", p->GetVersion().c_str());
+    snprintf(s_tmpOutBuf, MaxBuf, "%s", p->GetVersion().c_str());
 #else
-    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), p->GetVersion().c_str());
+    wnsprintf(s_tmpOutBuf, MaxBuf, _T("%s"), p->GetVersion().c_str());
 #endif
 
     return s_tmpOutBuf;
@@ -671,9 +671,9 @@ API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, MAX_BUF, "%s", p->GetExpr().c_str());
+    snprintf(s_tmpOutBuf, MaxBuf, "%s", p->GetExpr().c_str());
 #else
-    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), p->GetExpr().c_str());
+    wnsprintf(s_tmpOutBuf, MaxBuf, _T("%s"), p->GetExpr().c_str());
 #endif
 
     return s_tmpOutBuf;
@@ -1034,9 +1034,9 @@ API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, MAX_BUF, "%s", pMsg);
+    snprintf(s_tmpOutBuf, MaxBuf, "%s", pMsg);
 #else
-    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), pMsg);
+    wnsprintf(s_tmpOutBuf, MaxBuf, _T("%s"), pMsg);
 #endif
 
     return s_tmpOutBuf;
@@ -1053,9 +1053,9 @@ API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, MAX_BUF, "%s", pToken);
+    snprintf(s_tmpOutBuf, MaxBuf, "%s", pToken);
 #else
-    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), pToken);
+    wnsprintf(s_tmpOutBuf, MaxBuf, _T("%s"), pToken);
 #endif
 
     return s_tmpOutBuf;

--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -99,7 +99,8 @@ private:
     int m_nParserType;
 };
 
-static muChar_t s_tmpOutBuf[2048];
+const int MAX_BUF = 2048;
+static muChar_t s_tmpOutBuf[MAX_BUF];
 
 //---------------------------------------------------------------------------
 //
@@ -192,9 +193,9 @@ API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
         muParser_t* const p(AsParser(a_hParser));
 
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, 2048, "%s", p->GetVersion().c_str());
+    snprintf(s_tmpOutBuf, MAX_BUF, "%s", p->GetVersion().c_str());
 #else
-    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), p->GetVersion().c_str());
+    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), p->GetVersion().c_str());
 #endif
 
     return s_tmpOutBuf;
@@ -670,9 +671,9 @@ API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, 2048, "%s", p->GetExpr().c_str());
+    snprintf(s_tmpOutBuf, MAX_BUF, "%s", p->GetExpr().c_str());
 #else
-    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), p->GetExpr().c_str());
+    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), p->GetExpr().c_str());
 #endif
 
     return s_tmpOutBuf;
@@ -1033,9 +1034,9 @@ API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, 2048, "%s", pMsg);
+    snprintf(s_tmpOutBuf, MAX_BUF, "%s", pMsg);
 #else
-    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), pMsg);
+    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), pMsg);
 #endif
 
     return s_tmpOutBuf;
@@ -1052,9 +1053,9 @@ API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
     // C# explodes when pMsg is returned directly. For some reason it can't access
     // the memory where the message lies directly.
 #ifndef _UNICODE
-    snprintf(s_tmpOutBuf, 2048, "%s", pToken);
+    snprintf(s_tmpOutBuf, MAX_BUF, "%s", pToken);
 #else
-    wnsprintf(s_tmpOutBuf, 2048, _T("%s"), pToken);
+    wnsprintf(s_tmpOutBuf, MAX_BUF, _T("%s"), pToken);
 #endif
 
     return s_tmpOutBuf;


### PR DESCRIPTION
Changed all sprintf() functions (4 at lines 195, 673, 1036, 1055) to snprintf() functions with the value of 2048 (the original sprintf() writes to a buffer, s_tmpOutBuf, that was initialized with a size of 2048). The snprintf() function will now write a maximum of 2048 bytes of data to the buffer, which prevents writing past the end of the buffer into memory illegally. This adjustment does not change the functionality of the code as any read from the buffer will stop at the end of the buffer, and any characters that exceed the buffer length are discarded and does not cause the program to fail. A ./configure + make build does not fail or throw an error with the changes.