### PR TITLE
Export C++ symbols

### DIFF
--- a/include/muParser.h
+++ b/include/muParser.h
@@ -48,7 +48,7 @@ namespace mu
     muparser(at)beltoforion.de
     </small>
   */
-  /* final */ class Parser : public ParserBase
+  /* final */ class API_EXPORT Parser : public ParserBase
   {
   public:
 

--- a/include/muParserBase.h
+++ b/include/muParserBase.h
@@ -59,7 +59,7 @@ namespace mu
   Complementary to a set of internally implemented functions the parser is able to handle 
   user defined functions and variables. 
 */
-class ParserBase 
+class API_EXPORT ParserBase
 {
 friend class ParserTokenReader;
 

--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -47,7 +47,7 @@ namespace mu
 
     \author (C) 2004-2011 Ingo Berg
 */
-class ParserCallback
+class API_EXPORT ParserCallback
 {
 public:
     ParserCallback(fun_type0  a_pFun, bool a_bAllowOpti);

--- a/include/muParserDLL.h
+++ b/include/muParserDLL.h
@@ -25,19 +25,7 @@
 #ifndef MU_PARSER_DLL_H
 #define MU_PARSER_DLL_H
 
-#if defined(WIN32) || defined(_WIN32)
-    #if defined(MUPARSER_STATIC)
-        #define API_EXPORT(TYPE) TYPE __cdecl
-    #else
-        #ifdef MUPARSERLIB_EXPORTS
-            #define API_EXPORT(TYPE) __declspec(dllexport) TYPE __cdecl
-        #else
-            #define API_EXPORT(TYPE) __declspec(dllimport) TYPE __cdecl
-        #endif
-    #endif
-#else
-    #define API_EXPORT(TYPE) TYPE
-#endif
+#include "muParserFixes.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -115,127 +103,127 @@ static const int muBASETYPE_INT    = 1;
 
 
 // Basic operations / initialization  
-API_EXPORT(muParserHandle_t) mupCreate(int nBaseType);
-API_EXPORT(void) mupRelease(muParserHandle_t a_hParser);
-API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser);
-API_EXPORT(void) mupSetExpr(muParserHandle_t a_hParser, const muChar_t *a_szExpr);
-API_EXPORT(void) mupSetVarFactory(muParserHandle_t a_hParser, muFacFun_t a_pFactory, void* pUserData);
-API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser);
-API_EXPORT(muFloat_t) mupEval(muParserHandle_t a_hParser);
-API_EXPORT(muFloat_t*) mupEvalMulti(muParserHandle_t a_hParser, int *nNum);
-API_EXPORT(void) mupEvalBulk(muParserHandle_t a_hParser, muFloat_t *a_fResult, int nSize);
+API_EXPORT_C(muParserHandle_t) mupCreate(int nBaseType);
+API_EXPORT_C(void) mupRelease(muParserHandle_t a_hParser);
+API_EXPORT_C(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupSetExpr(muParserHandle_t a_hParser, const muChar_t *a_szExpr);
+API_EXPORT_C(void) mupSetVarFactory(muParserHandle_t a_hParser, muFacFun_t a_pFactory, void* pUserData);
+API_EXPORT_C(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser);
+API_EXPORT_C(muFloat_t) mupEval(muParserHandle_t a_hParser);
+API_EXPORT_C(muFloat_t*) mupEvalMulti(muParserHandle_t a_hParser, int *nNum);
+API_EXPORT_C(void) mupEvalBulk(muParserHandle_t a_hParser, muFloat_t *a_fResult, int nSize);
 
 // Defining callbacks / variables / constants
-API_EXPORT(void) mupDefineFun0(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun0_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun1(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun1_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun2(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun2_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun3(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun3_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun4(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun4_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun5(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun5_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun6(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun6_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun7(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun7_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun8(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun8_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun9(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun9_t a_pFun, muBool_t a_bOptimize);
-API_EXPORT(void) mupDefineFun10(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun10_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun0(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun0_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun1(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun1_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun2(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun2_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun3(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun3_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun4(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun4_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun5(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun5_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun6(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun6_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun7(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun7_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun8(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun8_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun9(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun9_t a_pFun, muBool_t a_bOptimize);
+API_EXPORT_C(void) mupDefineFun10(muParserHandle_t a_hParser, const muChar_t *a_szName, muFun10_t a_pFun, muBool_t a_bOptimize);
 
 // Defining bulkmode functions
-API_EXPORT(void) mupDefineBulkFun0(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun0_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun1(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun1_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun2(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun2_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun3(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun3_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun4(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun4_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun5(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun5_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun6(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun6_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun7(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun7_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun8(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun8_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun9(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun9_t a_pFun);
-API_EXPORT(void) mupDefineBulkFun10(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun10_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun0(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun0_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun1(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun1_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun2(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun2_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun3(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun3_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun4(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun4_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun5(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun5_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun6(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun6_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun7(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun7_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun8(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun8_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun9(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun9_t a_pFun);
+API_EXPORT_C(void) mupDefineBulkFun10(muParserHandle_t a_hParser, const muChar_t *a_szName, muBulkFun10_t a_pFun);
 
 // string functions
-API_EXPORT(void) mupDefineStrFun1(muParserHandle_t a_hParser, const muChar_t *a_szName, muStrFun1_t a_pFun);
-API_EXPORT(void) mupDefineStrFun2(muParserHandle_t a_hParser, const muChar_t *a_szName, muStrFun2_t a_pFun);
-API_EXPORT(void) mupDefineStrFun3(muParserHandle_t a_hParser, const muChar_t *a_szName, muStrFun3_t a_pFun);
+API_EXPORT_C(void) mupDefineStrFun1(muParserHandle_t a_hParser, const muChar_t *a_szName, muStrFun1_t a_pFun);
+API_EXPORT_C(void) mupDefineStrFun2(muParserHandle_t a_hParser, const muChar_t *a_szName, muStrFun2_t a_pFun);
+API_EXPORT_C(void) mupDefineStrFun3(muParserHandle_t a_hParser, const muChar_t *a_szName, muStrFun3_t a_pFun);
 
-API_EXPORT(void) mupDefineMultFun( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefineMultFun( muParserHandle_t a_hParser, 
                                    const muChar_t* a_szName, 
                                    muMultFun_t a_pFun, 
                                    muBool_t a_bOptimize);
 
-API_EXPORT(void) mupDefineOprt( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefineOprt( muParserHandle_t a_hParser, 
                                 const muChar_t* a_szName, 
                                 muFun2_t a_pFun, 
                                 muInt_t a_nPrec, 
                                 muInt_t a_nOprtAsct,
                                 muBool_t a_bOptimize);
 
-API_EXPORT(void) mupDefineConst( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefineConst( muParserHandle_t a_hParser, 
                                  const muChar_t* a_szName, 
                                  muFloat_t a_fVal );
 
-API_EXPORT(void) mupDefineStrConst( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefineStrConst( muParserHandle_t a_hParser, 
                                     const muChar_t* a_szName, 
                                     const muChar_t *a_sVal );
 
-API_EXPORT(void) mupDefineVar( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefineVar( muParserHandle_t a_hParser, 
                                const muChar_t* a_szName, 
                                muFloat_t *a_fVar);
 
-API_EXPORT(void) mupDefineBulkVar( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefineBulkVar( muParserHandle_t a_hParser, 
                                const muChar_t* a_szName, 
                                muFloat_t *a_fVar);
 
-API_EXPORT(void) mupDefinePostfixOprt( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefinePostfixOprt( muParserHandle_t a_hParser, 
                                        const muChar_t* a_szName, 
                                        muFun1_t a_pOprt, 
                                        muBool_t a_bOptimize);
 
 
-API_EXPORT(void) mupDefineInfixOprt( muParserHandle_t a_hParser, 
+API_EXPORT_C(void) mupDefineInfixOprt( muParserHandle_t a_hParser, 
                                      const muChar_t* a_szName, 
                                      muFun1_t a_pOprt, 
                                      muBool_t a_bOptimize);
 
 // Define character sets for identifiers
-API_EXPORT(void) mupDefineNameChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset);
-API_EXPORT(void) mupDefineOprtChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset);
-API_EXPORT(void) mupDefineInfixOprtChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset);
+API_EXPORT_C(void) mupDefineNameChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset);
+API_EXPORT_C(void) mupDefineOprtChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset);
+API_EXPORT_C(void) mupDefineInfixOprtChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset);
 
 // Remove all / single variables
-API_EXPORT(void) mupRemoveVar(muParserHandle_t a_hParser, const muChar_t* a_szName);
-API_EXPORT(void) mupClearVar(muParserHandle_t a_hParser);
-API_EXPORT(void) mupClearConst(muParserHandle_t a_hParser);
-API_EXPORT(void) mupClearOprt(muParserHandle_t a_hParser);
-API_EXPORT(void) mupClearFun(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupRemoveVar(muParserHandle_t a_hParser, const muChar_t* a_szName);
+API_EXPORT_C(void) mupClearVar(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupClearConst(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupClearOprt(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupClearFun(muParserHandle_t a_hParser);
 
 // Querying variables / expression variables / constants
-API_EXPORT(int) mupGetExprVarNum(muParserHandle_t a_hParser);
-API_EXPORT(int) mupGetVarNum(muParserHandle_t a_hParser);
-API_EXPORT(int) mupGetConstNum(muParserHandle_t a_hParser);
-API_EXPORT(void) mupGetExprVar(muParserHandle_t a_hParser, unsigned a_iVar, const muChar_t** a_pszName, muFloat_t** a_pVar);
-API_EXPORT(void) mupGetVar(muParserHandle_t a_hParser, unsigned a_iVar, const muChar_t** a_pszName, muFloat_t** a_pVar);
-API_EXPORT(void) mupGetConst(muParserHandle_t a_hParser, unsigned a_iVar, const muChar_t** a_pszName, muFloat_t* a_pVar);
-API_EXPORT(void) mupSetArgSep(muParserHandle_t a_hParser, const muChar_t cArgSep);
-API_EXPORT(void) mupSetDecSep(muParserHandle_t a_hParser, const muChar_t cArgSep);
-API_EXPORT(void) mupSetThousandsSep(muParserHandle_t a_hParser, const muChar_t cArgSep);
-API_EXPORT(void) mupResetLocale(muParserHandle_t a_hParser);
+API_EXPORT_C(int) mupGetExprVarNum(muParserHandle_t a_hParser);
+API_EXPORT_C(int) mupGetVarNum(muParserHandle_t a_hParser);
+API_EXPORT_C(int) mupGetConstNum(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupGetExprVar(muParserHandle_t a_hParser, unsigned a_iVar, const muChar_t** a_pszName, muFloat_t** a_pVar);
+API_EXPORT_C(void) mupGetVar(muParserHandle_t a_hParser, unsigned a_iVar, const muChar_t** a_pszName, muFloat_t** a_pVar);
+API_EXPORT_C(void) mupGetConst(muParserHandle_t a_hParser, unsigned a_iVar, const muChar_t** a_pszName, muFloat_t* a_pVar);
+API_EXPORT_C(void) mupSetArgSep(muParserHandle_t a_hParser, const muChar_t cArgSep);
+API_EXPORT_C(void) mupSetDecSep(muParserHandle_t a_hParser, const muChar_t cArgSep);
+API_EXPORT_C(void) mupSetThousandsSep(muParserHandle_t a_hParser, const muChar_t cArgSep);
+API_EXPORT_C(void) mupResetLocale(muParserHandle_t a_hParser);
 
 // Add value recognition callbacks
-API_EXPORT(void) mupAddValIdent(muParserHandle_t a_hParser, muIdentFun_t);
+API_EXPORT_C(void) mupAddValIdent(muParserHandle_t a_hParser, muIdentFun_t);
 
 // Error handling
-API_EXPORT(muBool_t) mupError(muParserHandle_t a_hParser);
-API_EXPORT(void) mupErrorReset(muParserHandle_t a_hParser);
-API_EXPORT(void) mupSetErrorHandler(muParserHandle_t a_hParser, muErrorHandler_t a_pErrHandler);
-API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser);
-API_EXPORT(muInt_t) mupGetErrorCode(muParserHandle_t a_hParser);
-API_EXPORT(muInt_t) mupGetErrorPos(muParserHandle_t a_hParser);
-API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser);
-//API_EXPORT(const muChar_t*) mupGetErrorExpr(muParserHandle_t a_hParser);
+API_EXPORT_C(muBool_t) mupError(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupErrorReset(muParserHandle_t a_hParser);
+API_EXPORT_C(void) mupSetErrorHandler(muParserHandle_t a_hParser, muErrorHandler_t a_pErrHandler);
+API_EXPORT_C(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser);
+API_EXPORT_C(muInt_t) mupGetErrorCode(muParserHandle_t a_hParser);
+API_EXPORT_C(muInt_t) mupGetErrorPos(muParserHandle_t a_hParser);
+API_EXPORT_C(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser);
+//API_EXPORT_C(const muChar_t*) mupGetErrorExpr(muParserHandle_t a_hParser);
 
 // This is used for .NET only. It creates a new variable allowing the dll to
 // manage the variable rather than the .NET garbage collector.
-API_EXPORT(muFloat_t*) mupCreateVar();
-API_EXPORT(void) mupReleaseVar(muFloat_t*);
+API_EXPORT_C(muFloat_t*) mupCreateVar();
+API_EXPORT_C(void) mupReleaseVar(muFloat_t*);
 
 #ifdef __cplusplus
 }

--- a/include/muParserError.h
+++ b/include/muParserError.h
@@ -125,7 +125,7 @@ private:
 
   Part of the math parser package.
 */
-class ParserError
+class API_EXPORT ParserError
 {
 private:
 

--- a/include/muParserFixes.h
+++ b/include/muParserFixes.h
@@ -57,6 +57,49 @@
 
 #endif
 
+
+/* From http://gcc.gnu.org/wiki/Visibility */
+/* Generic helper definitions for shared library support */
+#if defined _WIN32 || defined __CYGWIN__
+#define MUPARSER_HELPER_DLL_IMPORT __declspec(dllimport)
+#define MUPARSER_HELPER_DLL_EXPORT __declspec(dllexport)
+#define MUPARSER_HELPER_DLL_LOCAL
+#else
+#if __GNUC__ >= 4
+#define MUPARSER_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
+#define MUPARSER_HELPER_DLL_EXPORT __attribute__ ((visibility ("default")))
+#define MUPARSER_HELPER_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+#else
+#define MUPARSER_HELPER_DLL_IMPORT
+#define MUPARSER_HELPER_DLL_EXPORT
+#define MUPARSER_HELPER_DLL_LOCAL
+#endif
+#endif
+
+/* Now we use the generic helper definitions above to define API_EXPORT and MUPARSER_LOCAL.
+ * API_EXPORT is used for the public API symbols. It either DLL imports or DLL exports (or does nothing for static build)
+ * MUPARSER_LOCAL is used for non-api symbols. */
+
+#ifndef MUPARSER_STATIC /* defined if muParser is compiled as a DLL */
+#ifdef MUPARSERLIB_EXPORTS /* defined if we are building the muParser DLL (instead of using it) */
+#define API_EXPORT MUPARSER_HELPER_DLL_EXPORT
+#else
+#define API_EXPORT MUPARSER_HELPER_DLL_IMPORT
+#endif /* MUPARSER_DLL_EXPORTS */
+#define MUPARSER_LOCAL MUPARSER_HELPER_DLL_LOCAL
+#else /* MUPARSER_STATIC is defined: this means muParser is a static lib. */
+#define API_EXPORT
+#define MUPARSER_LOCAL
+#endif /* !MUPARSER_STATIC */
+
+
+#ifdef _WIN32
+#define API_EXPORT_C(TYPE) API_EXPORT TYPE __cdecl
+#else
+#define API_EXPORT_C(TYPE) TYPE
+#endif
+
+
 #endif // include guard
 
 

--- a/include/muParserTest.h
+++ b/include/muParserTest.h
@@ -46,7 +46,7 @@ namespace mu
 
       (C) 2004-2011 Ingo Berg
     */
-    class ParserTester // final
+    class API_EXPORT ParserTester // final
     {
     private:
         static int c_iCount;

--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -153,7 +153,7 @@ BOOL APIENTRY DllMain(HANDLE /*hModule*/,
 //
 //---------------------------------------------------------------------------
 
-API_EXPORT(void) mupSetVarFactory(muParserHandle_t a_hParser, muFacFun_t a_pFactory, void *pUserData)
+API_EXPORT_C(void) mupSetVarFactory(muParserHandle_t a_hParser, muFacFun_t a_pFactory, void *pUserData)
 {
     MU_TRY
         muParser_t* p(AsParser(a_hParser));
@@ -164,7 +164,7 @@ API_EXPORT(void) mupSetVarFactory(muParserHandle_t a_hParser, muFacFun_t a_pFact
 //---------------------------------------------------------------------------
 /** \brief Create a new Parser instance and return its handle.
 */
-API_EXPORT(muParserHandle_t) mupCreate(int nBaseType)
+API_EXPORT_C(muParserHandle_t) mupCreate(int nBaseType)
 {
     switch (nBaseType)
     {
@@ -177,7 +177,7 @@ API_EXPORT(muParserHandle_t) mupCreate(int nBaseType)
 //---------------------------------------------------------------------------
 /** \brief Release the parser instance related with a parser handle.
 */
-API_EXPORT(void) mupRelease(muParserHandle_t a_hParser)
+API_EXPORT_C(void) mupRelease(muParserHandle_t a_hParser)
 {
     MU_TRY
         ParserTag* p = static_cast<ParserTag*>(a_hParser);
@@ -186,7 +186,7 @@ API_EXPORT(void) mupRelease(muParserHandle_t a_hParser)
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
+API_EXPORT_C(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -206,7 +206,7 @@ API_EXPORT(const muChar_t*) mupGetVersion(muParserHandle_t a_hParser)
 //---------------------------------------------------------------------------
 /** \brief Evaluate the expression.
 */
-API_EXPORT(muFloat_t) mupEval(muParserHandle_t a_hParser)
+API_EXPORT_C(muFloat_t) mupEval(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -217,7 +217,7 @@ API_EXPORT(muFloat_t) mupEval(muParserHandle_t a_hParser)
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(muFloat_t*) mupEvalMulti(muParserHandle_t a_hParser, int *nNum)
+API_EXPORT_C(muFloat_t*) mupEvalMulti(muParserHandle_t a_hParser, int *nNum)
 {
     MU_TRY
         assert(nNum != NULL);
@@ -230,7 +230,7 @@ API_EXPORT(muFloat_t*) mupEvalMulti(muParserHandle_t a_hParser, int *nNum)
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupEvalBulk(muParserHandle_t a_hParser, muFloat_t *a_res, int nSize)
+API_EXPORT_C(void) mupEvalBulk(muParserHandle_t a_hParser, muFloat_t *a_res, int nSize)
 {
     MU_TRY
         muParser_t* p(AsParser(a_hParser));
@@ -239,7 +239,7 @@ API_EXPORT(void) mupEvalBulk(muParserHandle_t a_hParser, muFloat_t *a_res, int n
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupSetExpr(muParserHandle_t a_hParser, const muChar_t* a_szExpr)
+API_EXPORT_C(void) mupSetExpr(muParserHandle_t a_hParser, const muChar_t* a_szExpr)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -248,7 +248,7 @@ API_EXPORT(void) mupSetExpr(muParserHandle_t a_hParser, const muChar_t* a_szExpr
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupRemoveVar(muParserHandle_t a_hParser, const muChar_t* a_szName)
+API_EXPORT_C(void) mupRemoveVar(muParserHandle_t a_hParser, const muChar_t* a_szName)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -260,7 +260,7 @@ API_EXPORT(void) mupRemoveVar(muParserHandle_t a_hParser, const muChar_t* a_szNa
 /** \brief Release all parser variables.
     \param a_hParser Handle to the parser instance.
     */
-API_EXPORT(void) mupClearVar(muParserHandle_t a_hParser)
+API_EXPORT_C(void) mupClearVar(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -272,7 +272,7 @@ API_EXPORT(void) mupClearVar(muParserHandle_t a_hParser)
 /** \brief Release all parser variables.
     \param a_hParser Handle to the parser instance.
     */
-API_EXPORT(void) mupClearConst(muParserHandle_t a_hParser)
+API_EXPORT_C(void) mupClearConst(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -284,7 +284,7 @@ API_EXPORT(void) mupClearConst(muParserHandle_t a_hParser)
 /** \brief Clear all user defined operators.
     \param a_hParser Handle to the parser instance.
     */
-API_EXPORT(void) mupClearOprt(muParserHandle_t a_hParser)
+API_EXPORT_C(void) mupClearOprt(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -293,7 +293,7 @@ API_EXPORT(void) mupClearOprt(muParserHandle_t a_hParser)
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupClearFun(muParserHandle_t a_hParser)
+API_EXPORT_C(void) mupClearFun(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -302,7 +302,7 @@ API_EXPORT(void) mupClearFun(muParserHandle_t a_hParser)
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun0(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun0(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muFun0_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -314,7 +314,7 @@ API_EXPORT(void) mupDefineFun0(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun1(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun1(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muFun1_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -326,7 +326,7 @@ API_EXPORT(void) mupDefineFun1(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun2(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun2(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muFun2_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -338,7 +338,7 @@ API_EXPORT(void) mupDefineFun2(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun3(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun3(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun3_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -350,7 +350,7 @@ API_EXPORT(void) mupDefineFun3(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun4(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun4(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun4_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -362,7 +362,7 @@ API_EXPORT(void) mupDefineFun4(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun5(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun5(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun5_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -374,7 +374,7 @@ API_EXPORT(void) mupDefineFun5(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun6(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun6(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun6_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -386,7 +386,7 @@ API_EXPORT(void) mupDefineFun6(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun7(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun7(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun7_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -398,7 +398,7 @@ API_EXPORT(void) mupDefineFun7(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun8(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun8(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun8_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -410,7 +410,7 @@ API_EXPORT(void) mupDefineFun8(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun9(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun9(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun9_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -422,7 +422,7 @@ API_EXPORT(void) mupDefineFun9(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineFun10(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineFun10(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFun10_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -434,7 +434,7 @@ API_EXPORT(void) mupDefineFun10(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun0(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun0(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muBulkFun0_t a_pFun)
 {
@@ -445,7 +445,7 @@ API_EXPORT(void) mupDefineBulkFun0(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun1(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun1(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muBulkFun1_t a_pFun)
 {
@@ -456,7 +456,7 @@ API_EXPORT(void) mupDefineBulkFun1(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun2(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun2(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muBulkFun2_t a_pFun)
 {
@@ -467,7 +467,7 @@ API_EXPORT(void) mupDefineBulkFun2(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun3(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun3(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun3_t a_pFun)
 {
@@ -478,7 +478,7 @@ API_EXPORT(void) mupDefineBulkFun3(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun4(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun4(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun4_t a_pFun)
 {
@@ -489,7 +489,7 @@ API_EXPORT(void) mupDefineBulkFun4(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun5(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun5(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun5_t a_pFun)
 {
@@ -500,7 +500,7 @@ API_EXPORT(void) mupDefineBulkFun5(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun6(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun6(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun6_t a_pFun)
 {
@@ -511,7 +511,7 @@ API_EXPORT(void) mupDefineBulkFun6(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun7(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun7(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun7_t a_pFun)
 {
@@ -522,7 +522,7 @@ API_EXPORT(void) mupDefineBulkFun7(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun8(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun8(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun8_t a_pFun)
 {
@@ -533,7 +533,7 @@ API_EXPORT(void) mupDefineBulkFun8(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun9(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun9(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun9_t a_pFun)
 {
@@ -544,7 +544,7 @@ API_EXPORT(void) mupDefineBulkFun9(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkFun10(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkFun10(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muBulkFun10_t a_pFun)
 {
@@ -555,7 +555,7 @@ API_EXPORT(void) mupDefineBulkFun10(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineStrFun1(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineStrFun1(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muStrFun1_t a_pFun)
 {
@@ -566,7 +566,7 @@ API_EXPORT(void) mupDefineStrFun1(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineStrFun2(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineStrFun2(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muStrFun2_t a_pFun)
 {
@@ -577,7 +577,7 @@ API_EXPORT(void) mupDefineStrFun2(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineStrFun3(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineStrFun3(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muStrFun3_t a_pFun)
 {
@@ -588,7 +588,7 @@ API_EXPORT(void) mupDefineStrFun3(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineMultFun(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineMultFun(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muMultFun_t a_pFun,
     muBool_t a_bAllowOpt)
@@ -600,7 +600,7 @@ API_EXPORT(void) mupDefineMultFun(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineOprt(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineOprt(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muFun2_t a_pFun,
     muInt_t a_nPrec,
@@ -618,7 +618,7 @@ API_EXPORT(void) mupDefineOprt(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineVar(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineVar(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFloat_t *a_pVar)
 {
@@ -629,7 +629,7 @@ API_EXPORT(void) mupDefineVar(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineBulkVar(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineBulkVar(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFloat_t *a_pVar)
 {
@@ -640,7 +640,7 @@ API_EXPORT(void) mupDefineBulkVar(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineConst(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineConst(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     muFloat_t a_fVal)
 {
@@ -651,7 +651,7 @@ API_EXPORT(void) mupDefineConst(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineStrConst(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineStrConst(muParserHandle_t a_hParser,
     const muChar_t *a_szName,
     const muChar_t *a_szVal)
 {
@@ -662,7 +662,7 @@ API_EXPORT(void) mupDefineStrConst(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
+API_EXPORT_C(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -683,7 +683,7 @@ API_EXPORT(const muChar_t*) mupGetExpr(muParserHandle_t a_hParser)
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefinePostfixOprt(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefinePostfixOprt(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muFun1_t a_pOprt,
     muBool_t a_bAllowOpt)
@@ -695,7 +695,7 @@ API_EXPORT(void) mupDefinePostfixOprt(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineInfixOprt(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineInfixOprt(muParserHandle_t a_hParser,
     const muChar_t* a_szName,
     muFun1_t a_pOprt,
     muBool_t a_bAllowOpt)
@@ -708,7 +708,7 @@ API_EXPORT(void) mupDefineInfixOprt(muParserHandle_t a_hParser,
 
 // Define character sets for identifiers
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineNameChars(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineNameChars(muParserHandle_t a_hParser,
     const muChar_t* a_szCharset)
 {
     muParser_t* const p(AsParser(a_hParser));
@@ -716,7 +716,7 @@ API_EXPORT(void) mupDefineNameChars(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineOprtChars(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineOprtChars(muParserHandle_t a_hParser,
     const muChar_t* a_szCharset)
 {
     muParser_t* const p(AsParser(a_hParser));
@@ -724,7 +724,7 @@ API_EXPORT(void) mupDefineOprtChars(muParserHandle_t a_hParser,
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupDefineInfixOprtChars(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupDefineInfixOprtChars(muParserHandle_t a_hParser,
     const muChar_t *a_szCharset)
 {
     muParser_t* const p(AsParser(a_hParser));
@@ -737,7 +737,7 @@ API_EXPORT(void) mupDefineInfixOprtChars(muParserHandle_t a_hParser,
     \return The number of used variables.
     \sa mupGetExprVar
     */
-API_EXPORT(int) mupGetVarNum(muParserHandle_t a_hParser)
+API_EXPORT_C(int) mupGetVarNum(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -764,7 +764,7 @@ API_EXPORT(int) mupGetVarNum(muParserHandle_t a_hParser)
     During the calculation user defined callback functions present in the expression
     will be called, this is unavoidable.
     */
-API_EXPORT(void) mupGetVar(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupGetVar(muParserHandle_t a_hParser,
     unsigned a_iVar,
     const muChar_t **a_szName,
     muFloat_t **a_pVar)
@@ -813,7 +813,7 @@ API_EXPORT(void) mupGetVar(muParserHandle_t a_hParser,
     \return The number of used variables.
     \sa mupGetExprVar
     */
-API_EXPORT(int) mupGetExprVarNum(muParserHandle_t a_hParser)
+API_EXPORT_C(int) mupGetExprVarNum(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -841,7 +841,7 @@ API_EXPORT(int) mupGetExprVarNum(muParserHandle_t a_hParser)
     \param a_pVar [out] Pointer to the variable.
     \throw nothrow
     */
-API_EXPORT(void) mupGetExprVar(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupGetExprVar(muParserHandle_t a_hParser,
     unsigned a_iVar,
     const muChar_t **a_szName,
     muFloat_t **a_pVar)
@@ -886,7 +886,7 @@ API_EXPORT(void) mupGetExprVar(muParserHandle_t a_hParser,
 
 //---------------------------------------------------------------------------
 /** \brief Return the number of constants defined in a parser. */
-API_EXPORT(int) mupGetConstNum(muParserHandle_t a_hParser)
+API_EXPORT_C(int) mupGetConstNum(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -898,7 +898,7 @@ API_EXPORT(int) mupGetConstNum(muParserHandle_t a_hParser)
 }
 
 //-----------------------------------------------------------------------------------------------------
-API_EXPORT(void) mupSetArgSep(muParserHandle_t a_hParser, const muChar_t cArgSep)
+API_EXPORT_C(void) mupSetArgSep(muParserHandle_t a_hParser, const muChar_t cArgSep)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -907,7 +907,7 @@ API_EXPORT(void) mupSetArgSep(muParserHandle_t a_hParser, const muChar_t cArgSep
 }
 
 //-----------------------------------------------------------------------------------------------------
-API_EXPORT(void) mupResetLocale(muParserHandle_t a_hParser)
+API_EXPORT_C(void) mupResetLocale(muParserHandle_t a_hParser)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -916,7 +916,7 @@ API_EXPORT(void) mupResetLocale(muParserHandle_t a_hParser)
 }
 
 //-----------------------------------------------------------------------------------------------------
-API_EXPORT(void) mupSetDecSep(muParserHandle_t a_hParser, const muChar_t cDecSep)
+API_EXPORT_C(void) mupSetDecSep(muParserHandle_t a_hParser, const muChar_t cDecSep)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -925,7 +925,7 @@ API_EXPORT(void) mupSetDecSep(muParserHandle_t a_hParser, const muChar_t cDecSep
 }
 
 //-----------------------------------------------------------------------------------------------------
-API_EXPORT(void) mupSetThousandsSep(muParserHandle_t a_hParser, const muChar_t cThousandsSep)
+API_EXPORT_C(void) mupSetThousandsSep(muParserHandle_t a_hParser, const muChar_t cThousandsSep)
 {
     MU_TRY
         muParser_t* const p(AsParser(a_hParser));
@@ -940,7 +940,7 @@ API_EXPORT(void) mupSetThousandsSep(muParserHandle_t a_hParser, const muChar_t c
     \param a_pszName [out] pointer to a null terminated string with the constant name
     \param [out] The constant value
     */
-API_EXPORT(void) mupGetConst(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupGetConst(muParserHandle_t a_hParser,
     unsigned a_iVar,
     const muChar_t **a_pszName,
     muFloat_t *a_fVal)
@@ -986,7 +986,7 @@ API_EXPORT(void) mupGetConst(muParserHandle_t a_hParser,
 //---------------------------------------------------------------------------
 /** \brief Add a custom value recognition function.
 */
-API_EXPORT(void) mupAddValIdent(muParserHandle_t a_hParser,
+API_EXPORT_C(void) mupAddValIdent(muParserHandle_t a_hParser,
     muIdentFun_t a_pFun)
 {
     MU_TRY
@@ -1001,7 +1001,7 @@ API_EXPORT(void) mupAddValIdent(muParserHandle_t a_hParser,
     After querying the internal error bit will be reset. So a consecutive call
     will return false.
     */
-API_EXPORT(muBool_t) mupError(muParserHandle_t a_hParser)
+API_EXPORT_C(muBool_t) mupError(muParserHandle_t a_hParser)
 {
     bool bError(AsParserTag(a_hParser)->bError);
     AsParserTag(a_hParser)->bError = false;
@@ -1011,13 +1011,13 @@ API_EXPORT(muBool_t) mupError(muParserHandle_t a_hParser)
 //---------------------------------------------------------------------------
 /** \brief Reset the internal error flag.
 */
-API_EXPORT(void) mupErrorReset(muParserHandle_t a_hParser)
+API_EXPORT_C(void) mupErrorReset(muParserHandle_t a_hParser)
 {
     AsParserTag(a_hParser)->bError = false;
 }
 
 //---------------------------------------------------------------------------
-API_EXPORT(void) mupSetErrorHandler(muParserHandle_t a_hParser, muErrorHandler_t a_pHandler)
+API_EXPORT_C(void) mupSetErrorHandler(muParserHandle_t a_hParser, muErrorHandler_t a_pHandler)
 {
     AsParserTag(a_hParser)->errHandler = a_pHandler;
 }
@@ -1025,7 +1025,7 @@ API_EXPORT(void) mupSetErrorHandler(muParserHandle_t a_hParser, muErrorHandler_t
 //---------------------------------------------------------------------------
 /** \brief Return the message associated with the last error.
 */
-API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
+API_EXPORT_C(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
 {
     ParserTag* const p(AsParserTag(a_hParser));
     const muChar_t *pMsg = p->exc.GetMsg().c_str();
@@ -1044,7 +1044,7 @@ API_EXPORT(const muChar_t*) mupGetErrorMsg(muParserHandle_t a_hParser)
 //---------------------------------------------------------------------------
 /** \brief Return the message associated with the last error.
 */
-API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
+API_EXPORT_C(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
 {
     ParserTag* const p(AsParserTag(a_hParser));
     const muChar_t *pToken = p->exc.GetToken().c_str();
@@ -1063,32 +1063,32 @@ API_EXPORT(const muChar_t*) mupGetErrorToken(muParserHandle_t a_hParser)
 //---------------------------------------------------------------------------
 /** \brief Return the code associated with the last error.
 */
-API_EXPORT(int) mupGetErrorCode(muParserHandle_t a_hParser)
+API_EXPORT_C(int) mupGetErrorCode(muParserHandle_t a_hParser)
 {
     return AsParserTag(a_hParser)->exc.GetCode();
 }
 
 //---------------------------------------------------------------------------
 /** \brief Return the position associated with the last error. */
-API_EXPORT(int) mupGetErrorPos(muParserHandle_t a_hParser)
+API_EXPORT_C(int) mupGetErrorPos(muParserHandle_t a_hParser)
 {
     return (int)AsParserTag(a_hParser)->exc.GetPos();
 }
 
 ////-----------------------------------------------------------------------------------------------------
-//API_EXPORT(const muChar_t*) mupGetErrorExpr(muParserHandle_t a_hParser)
+//API_EXPORT_C(const muChar_t*) mupGetErrorExpr(muParserHandle_t a_hParser)
 //{
 //  return AsParserTag(a_hParser)->exc.GetExpr().c_str();
 //}
 
 //-----------------------------------------------------------------------------------------------------
-API_EXPORT(muFloat_t*) mupCreateVar()
+API_EXPORT_C(muFloat_t*) mupCreateVar()
 {
     return new muFloat_t(0);
 }
 
 //-----------------------------------------------------------------------------------------------------
-API_EXPORT(void) mupReleaseVar(muFloat_t *ptr)
+API_EXPORT_C(void) mupReleaseVar(muFloat_t *ptr)
 {
     delete ptr;
 }


### PR DESCRIPTION
Moved API_EXPORT to API_EXPORT_C.
The new API_EXPORT macro exports c++ symbols and is used to declare exported classes.
These macro are defined in muParserFixes.h header.
This fixes #41.