### PR TITLE
Replace std::auto_ptr by std::unique_ptr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 # CMake based on work from @xantares
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.1.0)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # By default, build in Release mode. Must appear before project() command
 if (NOT DEFINED CMAKE_BUILD_TYPE)

--- a/include/muParserBase.h
+++ b/include/muParserBase.h
@@ -288,7 +288,7 @@ private:
     mutable stringbuf_type  m_vStringBuf; ///< String buffer, used for storing string function arguments
     stringbuf_type  m_vStringVarBuf;
 
-    std::auto_ptr<token_reader_type> m_pTokenReader; ///< Managed pointer to the token reader object.
+    std::unique_ptr<token_reader_type> m_pTokenReader; ///< Managed pointer to the token reader object.
 
     funmap_type  m_FunDef;         ///< Map of function names and pointers.
     funmap_type  m_PostOprtDef;    ///< Postfix operator callbacks

--- a/include/muParserToken.h
+++ b/include/muParserToken.h
@@ -69,7 +69,7 @@ namespace mu
       TString m_strTok;   ///< Token string
       TString m_strVal;   ///< Value for string variables
       value_type m_fVal;  ///< the value 
-      std::auto_ptr<ParserCallback> m_pCallback;
+      std::unique_ptr<ParserCallback> m_pCallback;
 
   public:
 

--- a/src/muParserTest.cpp
+++ b/src/muParserTest.cpp
@@ -1258,7 +1258,7 @@ namespace mu
 
       try
       {
-        std::auto_ptr<Parser> p1;
+        std::unique_ptr<Parser> p1;
         Parser  p2, p3;   // three parser objects
                           // they will be used for testing copy and assignment operators
         // p1 is a pointer since i'm going to delete it in order to test if

--- a/src/muParserTokenReader.cpp
+++ b/src/muParserTokenReader.cpp
@@ -147,7 +147,7 @@ namespace mu
   */
   ParserTokenReader* ParserTokenReader::Clone(ParserBase *a_pParent) const
   {
-    std::auto_ptr<ParserTokenReader> ptr(new ParserTokenReader(*this));
+    std::unique_ptr<ParserTokenReader> ptr(new ParserTokenReader(*this));
     ptr->SetParent(a_pParent);
     return ptr.release();
   }


### PR DESCRIPTION
Fixes #29. At least `libc++` started to remove `std::auto_ptr` from their implementation of the C++ standard library. In particular, Apple's `clang-9.1.0` which uses `libc++` by default refuses the existence of `std::auto_ptr` if compiled with `std=c++17` and we are running into this issue in dealii/dealii#6125.
Hence, it seems to be time to replace it by `std::unique_ptr`.