### PR TITLE
Avoid using single character string in muParserTokenReader

### DIFF
--- a/src/muParserTokenReader.cpp
+++ b/src/muParserTokenReader.cpp
@@ -902,7 +902,7 @@ namespace mu
     std::size_t iEnd(0), iSkip(0);
 
     // parser over escaped '\"' end replace them with '"'
-    for(iEnd=(int)strBuf.find( _T("\"") ); iEnd!=0 && iEnd!=string_type::npos; iEnd=(int)strBuf.find( _T("\""), iEnd))
+    for(iEnd=(int)strBuf.find( _T('\"') ); iEnd!=0 && iEnd!=string_type::npos; iEnd=(int)strBuf.find( _T('\"'), iEnd))
     {
       if (strBuf[iEnd-1]!='\\') break;
       strBuf.replace(iEnd-1, 2, _T("\"") );


### PR DESCRIPTION
`clang-tidy` suggests using a single character instead of a single character string. https://clang.llvm.org/extra/clang-tidy/checks/performance-faster-string-find.html