### PR TITLE
Export C++ symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(MUPARSER_VERSION ${MUPARSER_VERSION_MAJOR}.${MUPARSER_VERSION_MINOR}.${MUPAR
 # Build options
 option(ENABLE_SAMPLES "Build the samples" ON)
 option(ENABLE_OPENMP "Enable OpenMP for multithreading" OFF)
+option(BUILD_SHARED_LIBS "Build shared/static libs" ON)
 
 if(ENABLE_OPENMP)
     find_package(OpenMP REQUIRED)

--- a/include/muParser.h
+++ b/include/muParser.h
@@ -48,7 +48,7 @@ namespace mu
     muparser(at)beltoforion.de
     </small>
   */
-  /* final */ class Parser : public ParserBase
+  /* final */ class API_EXPORT_CXX Parser : public ParserBase
   {
   public:
 

--- a/include/muParserBase.h
+++ b/include/muParserBase.h
@@ -59,7 +59,7 @@ namespace mu
   Complementary to a set of internally implemented functions the parser is able to handle 
   user defined functions and variables. 
 */
-class ParserBase 
+class API_EXPORT_CXX ParserBase
 {
 friend class ParserTokenReader;
 

--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -47,7 +47,7 @@ namespace mu
 
     \author (C) 2004-2011 Ingo Berg
 */
-class ParserCallback
+class API_EXPORT_CXX ParserCallback
 {
 public:
     ParserCallback(fun_type0  a_pFun, bool a_bAllowOpti);

--- a/include/muParserDLL.h
+++ b/include/muParserDLL.h
@@ -25,19 +25,7 @@
 #ifndef MU_PARSER_DLL_H
 #define MU_PARSER_DLL_H
 
-#if defined(WIN32) || defined(_WIN32)
-    #if defined(MUPARSER_STATIC)
-        #define API_EXPORT(TYPE) TYPE __cdecl
-    #else
-        #ifdef MUPARSERLIB_EXPORTS
-            #define API_EXPORT(TYPE) __declspec(dllexport) TYPE __cdecl
-        #else
-            #define API_EXPORT(TYPE) __declspec(dllimport) TYPE __cdecl
-        #endif
-    #endif
-#else
-    #define API_EXPORT(TYPE) TYPE
-#endif
+#include "muParserFixes.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/include/muParserError.h
+++ b/include/muParserError.h
@@ -122,7 +122,7 @@ private:
 
   Part of the math parser package.
 */
-class ParserError
+class API_EXPORT_CXX ParserError
 {
 private:
 

--- a/include/muParserFixes.h
+++ b/include/muParserFixes.h
@@ -57,6 +57,49 @@
 
 #endif
 
+
+/* From http://gcc.gnu.org/wiki/Visibility */
+/* Generic helper definitions for shared library support */
+#if defined _WIN32 || defined __CYGWIN__
+#define MUPARSER_HELPER_DLL_IMPORT __declspec(dllimport)
+#define MUPARSER_HELPER_DLL_EXPORT __declspec(dllexport)
+#define MUPARSER_HELPER_DLL_LOCAL
+#else
+#if __GNUC__ >= 4
+#define MUPARSER_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
+#define MUPARSER_HELPER_DLL_EXPORT __attribute__ ((visibility ("default")))
+#define MUPARSER_HELPER_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+#else
+#define MUPARSER_HELPER_DLL_IMPORT
+#define MUPARSER_HELPER_DLL_EXPORT
+#define MUPARSER_HELPER_DLL_LOCAL
+#endif
+#endif
+
+/* Now we use the generic helper definitions above to define API_EXPORT_CXX and MUPARSER_LOCAL.
+ * API_EXPORT_CXX is used for the public API symbols. It either DLL imports or DLL exports (or does nothing for static build)
+ * MUPARSER_LOCAL is used for non-api symbols. */
+
+#ifndef MUPARSER_STATIC /* defined if muParser is compiled as a DLL */
+#ifdef MUPARSERLIB_EXPORTS /* defined if we are building the muParser DLL (instead of using it) */
+#define API_EXPORT_CXX MUPARSER_HELPER_DLL_EXPORT
+#else
+#define API_EXPORT_CXX MUPARSER_HELPER_DLL_IMPORT
+#endif /* MUPARSER_DLL_EXPORTS */
+#define MUPARSER_LOCAL MUPARSER_HELPER_DLL_LOCAL
+#else /* MUPARSER_STATIC is defined: this means muParser is a static lib. */
+#define API_EXPORT_CXX
+#define MUPARSER_LOCAL
+#endif /* !MUPARSER_STATIC */
+
+
+#ifdef _WIN32
+#define API_EXPORT(TYPE) API_EXPORT_CXX TYPE __cdecl
+#else
+#define API_EXPORT(TYPE) TYPE
+#endif
+
+
 #endif // include guard
 
 

--- a/include/muParserTest.h
+++ b/include/muParserTest.h
@@ -46,7 +46,7 @@ namespace mu
 
       (C) 2004-2011 Ingo Berg
     */
-    class ParserTester // final
+    class API_EXPORT_CXX ParserTester // final
     {
     private:
         static int c_iCount;


### PR DESCRIPTION
The new API_EXPORT_CXX macro exports c++ symbols and is used to declare exported classes.
This fixes #41.