### PR TITLE
Allow compilation as CMAKE subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic")
 endif()
 
-include_directories("${CMAKE_SOURCE_DIR}/include")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 add_library(muparser
     src/muParserBase.cpp
     src/muParserBytecode.cpp


### PR DESCRIPTION
This pull request allows the complete library repo to be included as subdirectory of an existing project.

When I included the repo as submodule, I got a "file not found error" of the muParser.h header file. I traced it back to the use of a specific CMAKE variable when adding the include path. According to https://stackoverflow.com/questions/53195186/difference-between-cmake-current-source-dir-cmake-source-dir-variables, CMAKE_CURRENT_SOURCE_DIR should be used instead of CMAKE_SOURCE_DIR.