### PR TITLE
Propagate muparser include directories to all dependent targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,6 @@ elseif(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-long-long -pedantic")
 endif()
 
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 add_library(muparser
     src/muParserBase.cpp
     src/muParserBytecode.cpp
@@ -57,6 +56,7 @@ add_library(muparser
     src/muParserTest.cpp
     src/muParserTokenReader.cpp
 )
+target_include_directories(muparser PUBLIC include)
 
 # this compiles the "DLL" interface (C API)
 target_compile_definitions(muparser PRIVATE MUPARSER_DLL)


### PR DESCRIPTION
This pull request prevents the need for a target linking to muparser to manually add the muParser include directory.

When consuming muParser in my project via `add_subdirectory()`, I received the fatal error: `muParser.h: No such file or directory`, so I had to manually add the include directory to my target.

Using `target_include_directories()` with scope `PUBLIC` instead of `include_directories()` allows to propagate the muparser include directory to all targets that link to it, as `include_directories()` only adds the include directories to targets in the current CMakeLists file.

CMake documentation at https://cmake.org/cmake/help/latest/command/include_directories.html states that `target_include_directories()` should be preferred to add include directories to individual targets and optionally propagate/export them to dependents.

Also note I added the include directory to the muparser library as `include` instead of `"${CMAKE_CURRENT_SOURCE_DIR}/include"` since relative paths are already interpreted as relative to the current source directory.
