### PR TITLE
Export muparser cmake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,11 @@ add_library(muparser
     src/muParserTest.cpp
     src/muParserTokenReader.cpp
 )
-target_include_directories(muparser PUBLIC include)
+# use the headers in the build-tree or the installed ones
+target_include_directories(muparser PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
 # this compiles the "DLL" interface (C API)
 target_compile_definitions(muparser PRIVATE MUPARSER_DLL)
@@ -84,9 +88,6 @@ set_target_properties(muparser PROPERTIES
     SOVERSION ${MUPARSER_VERSION_MAJOR}
 )
 
-# Install the export set for use with the install-tree
-export(TARGETS muparser FILE "${CMAKE_BINARY_DIR}/muparser-targets.cmake")
-
 if(ENABLE_SAMPLES)
   add_executable(example1 samples/example1/example1.cpp)
   target_link_libraries(example1 muparser)
@@ -98,8 +99,10 @@ endif()
 # The GNUInstallDirs defines ${CMAKE_INSTALL_DATAROOTDIR}
 # See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
 include (GNUInstallDirs)
+set(INSTALL_CONFIGDIR ${CMAKE_INSTALL_LIBDIR}/cmake/muparser)
 
 install(TARGETS muparser
+    EXPORT muparser-export
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT RuntimeLibraries
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT Development
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT RuntimeLibraries
@@ -120,6 +123,35 @@ install(FILES
     include/muParserToken.h
     include/muParserTokenReader.h
     DESTINATION include
+    COMPONENT Development
+)
+
+# Export the target under the build-tree (no need to install)
+export(EXPORT muparser-export
+    FILE "${CMAKE_BINARY_DIR}/muparser-targets.cmake"
+    NAMESPACE muparser::
+)
+
+# Export the installed target (typically for packaging)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/muparserConfigVersion.cmake"
+    VERSION ${MUPARSER_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+configure_file(muparserConfig.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/muparserConfig.cmake"
+    COPYONLY
+)
+install(EXPORT muparser-export
+    FILE muparser-targets.cmake
+    NAMESPACE muparser::
+    DESTINATION ${INSTALL_CONFIGDIR}
+)
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/muparserConfig.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/muparserConfigVersion.cmake
+    DESTINATION ${INSTALL_CONFIGDIR}
     COMPONENT Development
 )
 

--- a/muparserConfig.cmake.in
+++ b/muparserConfig.cmake.in
@@ -1,0 +1,6 @@
+get_filename_component(muparser_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+include(CMakeFindDependencyMacro)
+
+if(NOT TARGET muparser::muparser)
+    include("${muparser_CMAKE_DIR}/muparser-targets.cmake")
+endif()

--- a/samples/example3/CMakeLists.txt
+++ b/samples/example3/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.2)
+project(muparser-example3)
+
+# find muparser target already installed
+find_package(muparser 2.0 REQUIRED)
+
+add_executable(example3 example3.cpp)
+target_link_libraries(example3 muparser::muparser)
+
+include(CTest)
+add_test(example3 example3)
+

--- a/samples/example3/README.md
+++ b/samples/example3/README.md
@@ -1,0 +1,2 @@
+The example3 shows how to import and use muparser as an installed external
+dependency using cmake `find_package()`.

--- a/samples/example3/build.sh
+++ b/samples/example3/build.sh
@@ -1,0 +1,23 @@
+#!/bin/bash -x
+
+CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+MP_SOURCES=${CWD}/../../
+MP_BUILD=${CWD}/muparser-build
+MP_INSTALL=${CWD}/muparser-install
+EX3_BUILD_TREE=${CWD}/example3-using-buildtree
+EX3_INSTALL_TREE=${CWD}/example3-using-installtree
+
+# Build muparser and install it
+cmake -H${MP_SOURCES} -B${MP_BUILD} -DCMAKE_INSTALL_PREFIX=${MP_INSTALL}
+cmake --build ${MP_BUILD} --target install
+
+# Build the example using muparser build tree
+cmake -H${CWD} -B${EX3_BUILD_TREE} -DCMAKE_PREFIX_PATH=${MP_BUILD} 
+cmake --build ${EX3_BUILD_TREE} --target all
+cmake --build ${EX3_BUILD_TREE} --target test
+
+# Build the example using muparser install tree
+cmake -H${CWD} -B${EX3_INSTALL_TREE} -DCMAKE_PREFIX_PATH=${MP_INSTALL} 
+cmake --build ${EX3_INSTALL_TREE} --target all
+cmake --build ${EX3_INSTALL_TREE} --target test
+

--- a/samples/example3/example3.cpp
+++ b/samples/example3/example3.cpp
@@ -1,0 +1,49 @@
+/*
+
+    _____  __ _____________ _______  ______ ___________
+   /     \|  |  \____ \__  \\_  __ \/  ___// __ \_  __ \
+   |  Y Y  \  |  /  |_> > __ \|  | \/\___ \\  ___/|  | \/
+   |__|_|  /____/|   __(____  /__|  /____  >\___  >__|
+       \/      |__|       \/           \/     \/
+   Copyright (C) 2004 - 2020 Ingo Berg
+
+   Redistribution and use in source and binary forms, with or without modification, are permitted
+   provided that the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright notice, this list of
+      conditions and the following disclaimer.
+     * Redistributions in binary form must reproduce the above copyright notice, this list of
+      conditions and the following disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+   FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+   IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+   OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Small example using the cmake imported target. Include file and link library
+// should work automagically.
+
+#include <muParser.h>
+#include <muParserDef.h>
+
+int main()
+{
+   mu::Parser  parser;
+
+   mu::value_type  values[] = { 1, 2 };
+   parser.DefineVar("a", &values[0]);
+   parser.DefineVar("b", &values[1]);
+
+   std::string expr = "a + b";
+   parser.SetExpr("a + b");
+   mu::value_type ans = parser.Eval();
+   std::cout << expr << " == " << ans << "\n";
+
+   return (ans == 3.0) ? 0 : -1;
+}


### PR DESCRIPTION
Export muparser targets, such that client projects can
import it using find_package(). This mechanism for both the build tree
and the install tree. The provided example3 shows how to import muparser
targets.

Signed-off-by: Francis Giraldeau <francis.giraldeau@nrc-cnrc.gc.ca>