### PR TITLE
Allow for conditionally disabling tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,9 +168,11 @@ install(
 )
 
 include(CTest)
-enable_testing()
 
-add_executable (t_ParserTest test/t_ParserTest.cpp)
-target_link_libraries(t_ParserTest muparser)
-add_test (NAME ParserTest COMMAND t_ParserTest)
+if (BUILD_TESTING)
+    enable_testing()
 
+    add_executable (t_ParserTest test/t_ParserTest.cpp)
+    target_link_libraries(t_ParserTest muparser)
+    add_test (NAME ParserTest COMMAND t_ParserTest)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,8 +170,6 @@ install(
 include(CTest)
 
 if (BUILD_TESTING)
-    enable_testing()
-
     add_executable (t_ParserTest test/t_ParserTest.cpp)
     target_link_libraries(t_ParserTest muparser)
     add_test (NAME ParserTest COMMAND t_ParserTest)


### PR DESCRIPTION
This PR allows for disabling tests by setting BUILD_TESTING (built-in) option to OFF.
Tests are enabled by default.