### PR TITLE
[Modern C++] Adding missing overrides

### DIFF
--- a/include/muParser.h
+++ b/include/muParser.h
@@ -53,11 +53,11 @@ namespace mu
 
 		Parser();
 
-		virtual void InitCharSets();
-		virtual void InitFun();
-		virtual void InitConst();
-		virtual void InitOprt();
-		virtual void OnDetectVar(string_type* pExpr, int& nStart, int& nEnd);
+		void InitCharSets() override;
+		void InitFun() override;
+		void InitConst() override;
+		void InitOprt() override;
+		void OnDetectVar(string_type* pExpr, int& nStart, int& nEnd) override;
 
 		value_type Diff(value_type* a_Var, value_type a_fPos, value_type a_fEpsilon = 0) const;
 

--- a/include/muParserBase.h
+++ b/include/muParserBase.h
@@ -208,17 +208,17 @@ namespace mu
 
 		protected:
 
-			virtual char_type do_decimal_point() const
+			char_type do_decimal_point() const override
 			{
 				return m_cDecPoint;
 			}
 
-			virtual char_type do_thousands_sep() const
+			char_type do_thousands_sep() const override
 			{
 				return m_cThousandsSep;
 			}
 
-			virtual std::string do_grouping() const
+			std::string do_grouping() const override
 			{
 				// fix for issue 4: https://code.google.com/p/muparser/issues/detail?id=4
 				// courtesy of Jens Bartsch

--- a/include/muParserInt.h
+++ b/include/muParserInt.h
@@ -131,10 +131,10 @@ namespace mu
 	public:
 		ParserInt();
 
-		virtual void InitFun();
-		virtual void InitOprt();
-		virtual void InitConst();
-		virtual void InitCharSets();
+		void InitFun() override;
+		void InitOprt() override;
+		void InitConst() override;
+		void InitCharSets() override;
 	};
 
 } // namespace mu


### PR DESCRIPTION
This has been automatically corrected using clang-tidy, a small tutorial in here:

https://github.com/KratosMultiphysics/Kratos/wiki/How-to-use-Clang-Tidy-to-automatically-correct-code

Best regards