### PR TITLE
Adding manual definitions to avoid issues with MSVC. Update README with new changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,8 +67,10 @@ target_compile_definitions(muparser PRIVATE MUPARSER_DLL)
 
 if (BUILD_SHARED_LIBS)
   target_compile_definitions(muparser PRIVATE MUPARSERLIB_EXPORTS)
+  add_definitions( -DMUPARSERLIB_EXPORTS )
 else ()
   target_compile_definitions(muparser PUBLIC MUPARSER_STATIC)
+  add_definitions( -DMUPARSER_STATIC )
 endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ The following new issues, discovered by oss-fuzz are fixed:
 
 Bugfixes:
 -----------
-* fixed a couple of issues for building the C-Interface (muParserDLL.cpp/.h) with wide character support.
+* Fixed a couple of issues for building the C-Interface (muParserDLL.cpp/.h) with wide character support.
 
 Fixed Compiler Warnings:
 -----------
@@ -44,6 +44,7 @@ Fixed Compiler Warnings:
 
 Changes:
 ------------
+* Adding missing overrides
 * Added a new option "-DENABLE_WIDE_CHAR" to CMake for building muparser with wide character support
 * export muparser targets, such that client projects can import it using find_package() (https://github.com/beltoforion/muparser/pull/81#event-3528671228)
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,7 @@ Fixed Compiler Warnings:
 
 Changes:
 ------------
+* Adding manual definitions to avoid potential issues with MSVC
 * Adding missing overrides
 * Added a new option "-DENABLE_WIDE_CHAR" to CMake for building muparser with wide character support
 * export muparser targets, such that client projects can import it using find_package() (https://github.com/beltoforion/muparser/pull/81#event-3528671228)


### PR DESCRIPTION
Basically the title says. The manual definitions avoid issues with the MSVC (this for example happens with the Github CI we consider in our project: https://github.com/KratosMultiphysics/Kratos/pull/7899)