### PR TITLE
trivial cleanup of ParserCallback & add methods

### DIFF
--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -91,6 +91,7 @@ namespace mu
 		ParserCallback* Clone() const;
 
 		bool  IsOptimizable() const;
+		bool  IsValid() const;
 		void* GetAddr() const;
 		ECmdCode  GetCode() const;
 		ETypeCode GetType() const;

--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -100,6 +100,8 @@ namespace mu
 		int GetArgc() const;
 
 	private:
+		void Assign(const ParserCallback& ref);
+
 		void* m_pFun;                   ///< Pointer to the callback function, casted to void
 
 		/** \brief Number of numeric function arguments

--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -85,7 +85,7 @@ namespace mu
 		ParserCallback(strfun_type5 a_pFun, bool a_bAllowOpti);
 		ParserCallback();
 		ParserCallback(const ParserCallback& a_Fun);
-    ParserCallback & operator=(const ParserCallback& a_Fun);
+		ParserCallback & operator=(const ParserCallback& a_Fun);
 
 		ParserCallback* Clone() const;
 

--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -86,6 +86,7 @@ namespace mu
 		ParserCallback();
 		ParserCallback(const ParserCallback& a_Fun);
 		ParserCallback & operator=(const ParserCallback& a_Fun);
+		~ParserCallback();
 
 		ParserCallback* Clone() const;
 

--- a/include/muParserToken.h
+++ b/include/muParserToken.h
@@ -170,7 +170,7 @@ namespace mu
 		/** \brief Set Callback type. */
 		ParserToken& Set(const ParserCallback& a_pCallback, const TString& a_sTok)
 		{
-			MUP_ASSERT(a_pCallback.GetAddr());
+			MUP_ASSERT(a_pCallback.IsValid());
 
 			m_iCode = a_pCallback.GetCode();
 			m_iType = tpVOID;
@@ -380,7 +380,7 @@ namespace mu
 		{
 			MUP_ASSERT(m_pCallback.get());
 
-			if (!m_pCallback->GetAddr())
+			if (!m_pCallback->IsValid())
 				throw ParserError(ecINTERNAL_ERROR);
 
 			return m_pCallback->GetArgc();

--- a/src/muParserBase.cpp
+++ b/src/muParserBase.cpp
@@ -339,7 +339,7 @@ namespace mu
 		funmap_type& a_Storage,
 		const char_type* a_szCharSet)
 	{
-		if (a_Callback.GetAddr() == 0)
+		if (!a_Callback.IsValid())
 			Error(ecINVALID_FUN_PTR);
 
 		const funmap_type* pFunMap = &a_Storage;

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -404,20 +404,20 @@ namespace mu
 		m_eOprtAsct = ref.m_eOprtAsct;
 	}
 
-  ParserCallback & ParserCallback::operator=(const ParserCallback & ref)
-  {
-    if (this != &ref)
-    {
-      m_pFun = ref.m_pFun;
-      m_iArgc = ref.m_iArgc;
-      m_bAllowOpti = ref.m_bAllowOpti;
-      m_iCode = ref.m_iCode;
-      m_iType = ref.m_iType;
-      m_iPri = ref.m_iPri;
-      m_eOprtAsct = ref.m_eOprtAsct;
-    }
-    return *this;
-  }
+	ParserCallback & ParserCallback::operator=(const ParserCallback & ref)
+	{
+		if (this != &ref)
+		{
+			m_pFun = ref.m_pFun;
+			m_iArgc = ref.m_iArgc;
+			m_bAllowOpti = ref.m_bAllowOpti;
+			m_iCode = ref.m_iCode;
+			m_iType = ref.m_iType;
+			m_iPri = ref.m_iPri;
+			m_eOprtAsct = ref.m_eOprtAsct;
+		}
+		return *this;
+	}
 
 	/** \brief Clone this instance and return a pointer to the new instance. */
 	ParserCallback* ParserCallback::Clone() const

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -395,6 +395,28 @@ namespace mu
 	*/
 	ParserCallback::ParserCallback(const ParserCallback& ref)
 	{
+		Assign(ref);
+	}
+
+	ParserCallback & ParserCallback::operator=(const ParserCallback & ref)
+	{
+		Assign(ref);
+		return *this;
+	}
+
+
+	ParserCallback::~ParserCallback() = default;
+
+
+	/** \brief Copy callback from argument.
+
+		\throw nothrow
+	*/
+	void ParserCallback::Assign(const ParserCallback& ref)
+	{
+		if (this == &ref)
+			return;
+
 		m_pFun = ref.m_pFun;
 		m_iArgc = ref.m_iArgc;
 		m_bAllowOpti = ref.m_bAllowOpti;
@@ -403,24 +425,6 @@ namespace mu
 		m_iPri = ref.m_iPri;
 		m_eOprtAsct = ref.m_eOprtAsct;
 	}
-
-	ParserCallback & ParserCallback::operator=(const ParserCallback & ref)
-	{
-		if (this != &ref)
-		{
-			m_pFun = ref.m_pFun;
-			m_iArgc = ref.m_iArgc;
-			m_bAllowOpti = ref.m_bAllowOpti;
-			m_iCode = ref.m_iCode;
-			m_iType = ref.m_iType;
-			m_iPri = ref.m_iPri;
-			m_eOprtAsct = ref.m_eOprtAsct;
-		}
-		return *this;
-	}
-
-
-	ParserCallback::~ParserCallback() = default;
 
 
 	/** \brief Clone this instance and return a pointer to the new instance. */

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -419,6 +419,10 @@ namespace mu
 		return *this;
 	}
 
+
+	ParserCallback::~ParserCallback() = default;
+
+
 	/** \brief Clone this instance and return a pointer to the new instance. */
 	ParserCallback* ParserCallback::Clone() const
 	{

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -455,6 +455,17 @@ namespace mu
 	}
 
 
+	/** \brief Check that the callback looks valid
+		\throw nothrow
+
+		Check that the function pointer is not null.
+	*/
+	bool ParserCallback::IsValid() const
+	{
+		return m_pFun != nullptr;
+	}
+
+
 	/** \brief Return the callback code. */
 	ECmdCode  ParserCallback::GetCode() const
 	{


### PR DESCRIPTION
The goal of the out-of-line destructor, and of IsValid() instead of testing GetAddr() against nullptr, is to allow more backward binary compatible evolutions of ParserCallback (which has some impact on application binary code given the type is used through the method template ParserBase::DefineFun<>() )
