### PR TITLE
add void* user data variants for fun, bulkfun, multfun, and strfun

### DIFF
--- a/include/muParserBase.h
+++ b/include/muParserBase.h
@@ -141,6 +141,19 @@ namespace mu
 			AddCallback(a_strName, ParserCallback(a_pFun, a_bAllowOpt), m_FunDef, ValidNameChars());
 		}
 
+		/** \fn void mu::ParserBase::DefineFunUserData
+			\brief Define a parser function with user data (not null).
+			\param a_strName Name of the function
+			\param a_pFun Pointer to the callback function
+			\param a_pUserData Pointer that will be passed back to callback (shall not be nullptr)
+			\param a_bAllowOpt A flag indicating this function may be optimized
+		*/
+		template<typename T>
+		void DefineFunUserData(const string_type& a_strName, T a_pFun, void* a_pUserData, bool a_bAllowOpt = true)
+		{
+			AddCallback(a_strName, ParserCallback(a_pFun, a_pUserData, a_bAllowOpt), m_FunDef, ValidNameChars());
+		}
+
 		void DefineOprt(const string_type& a_strName, fun_type2 a_pFun, unsigned a_iPri = 0, EOprtAssociativity a_eAssociativity = oaLEFT, bool a_bAllowOpt = false);
 		void DefineConst(const string_type& a_sName, value_type a_fVal);
 		void DefineStrConst(const string_type& a_sName, const string_type& a_strVal);

--- a/include/muParserBytecode.h
+++ b/include/muParserBytecode.h
@@ -59,11 +59,11 @@ namespace mu
 
 			struct //SFunData
 			{
-				// Note: generic_fun_type is merely a placeholder. The real type could be 
-				//       anything between gun_type1 and fun_type9. I can't use a void
-				//       pointer due to constraints in the ANSI standard which allows
-				//       data pointers and function pointers to differ in size.
-				generic_fun_type ptr;
+				// Note: the type is erased in generic_callable_type and the signature of the
+				//       function to call is tracked elsewhere in regard with the number of
+				//       parameters (args) and the general kind of function (Cmd: cmFUNC,
+				//       cmFUNC_STR, or cmFUNC_BULK)
+				generic_callable_type cb;
 				int   argc;
 				int   idx;
 			} Fun;
@@ -119,9 +119,9 @@ namespace mu
 		void AddOp(ECmdCode a_Oprt);
 		void AddIfElse(ECmdCode a_Oprt);
 		void AddAssignOp(value_type* a_pVar);
-		void AddFun(generic_fun_type a_pFun, int a_iArgc);
-		void AddBulkFun(generic_fun_type a_pFun, int a_iArgc);
-		void AddStrFun(generic_fun_type a_pFun, int a_iArgc, int a_iIdx);
+		void AddFun(generic_callable_type a_pFun, int a_iArgc);
+		void AddBulkFun(generic_callable_type a_pFun, int a_iArgc);
+		void AddStrFun(generic_callable_type a_pFun, int a_iArgc, int a_iIdx);
 
 		void EnableOptimizer(bool bStat);
 

--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -104,12 +104,7 @@ namespace mu
 
 		void* m_pFun;                   ///< Pointer to the callback function, casted to void
 
-		/** \brief Number of numeric function arguments
-
-			This number is negative for functions with variable number of arguments. in this cases
-			they represent the actual number of arguments found.
-		*/
-		int   m_iArgc;
+		int   m_iArgc;                  ///< Internal representation of number of numeric function arguments
 		int   m_iPri;                   ///< Valid only for binary and infix operators; Operator precedence.
 		EOprtAssociativity m_eOprtAsct; ///< Operator associativity; Valid only for binary operators 
 		ECmdCode  m_iCode;

--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -78,11 +78,46 @@ namespace mu
 		ParserCallback(bulkfun_type10 a_pFun, bool a_bAllowOpti);
 
 		ParserCallback(multfun_type a_pFun, bool a_bAllowOpti);
+
 		ParserCallback(strfun_type1 a_pFun, bool a_bAllowOpti);
 		ParserCallback(strfun_type2 a_pFun, bool a_bAllowOpti);
 		ParserCallback(strfun_type3 a_pFun, bool a_bAllowOpti);
 		ParserCallback(strfun_type4 a_pFun, bool a_bAllowOpti);
 		ParserCallback(strfun_type5 a_pFun, bool a_bAllowOpti);
+
+		// note: a_pUserData shall not be nullptr
+		ParserCallback(fun_userdata_type0  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type1  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type2  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type3  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type4  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type5  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type6  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type7  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type8  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type9  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(fun_userdata_type10 a_pFun, void* a_pUserData, bool a_bAllowOpti);
+
+		ParserCallback(bulkfun_userdata_type0  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type1  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type2  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type3  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type4  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type5  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type6  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type7  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type8  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type9  a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(bulkfun_userdata_type10 a_pFun, void* a_pUserData, bool a_bAllowOpti);
+
+		ParserCallback(multfun_userdata_type a_pFun, void* a_pUserData, bool a_bAllowOpti);
+
+		ParserCallback(strfun_userdata_type1 a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(strfun_userdata_type2 a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(strfun_userdata_type3 a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(strfun_userdata_type4 a_pFun, void* a_pUserData, bool a_bAllowOpti);
+		ParserCallback(strfun_userdata_type5 a_pFun, void* a_pUserData, bool a_bAllowOpti);
+
 		ParserCallback();
 		ParserCallback(const ParserCallback& a_Fun);
 		ParserCallback & operator=(const ParserCallback& a_Fun);
@@ -93,6 +128,7 @@ namespace mu
 		bool  IsOptimizable() const;
 		bool  IsValid() const;
 		void* GetAddr() const;
+		void* GetUserData() const;
 		ECmdCode  GetCode() const;
 		ETypeCode GetType() const;
 		int GetPri()  const;
@@ -102,7 +138,7 @@ namespace mu
 	private:
 		void Assign(const ParserCallback& ref);
 
-		void* m_pFun;                   ///< Pointer to the callback function, casted to void
+		void* m_pFun;                   ///< Pointer to the callback function or internal data, casted to void
 
 		int   m_iArgc;                  ///< Internal representation of number of numeric function arguments
 		int   m_iPri;                   ///< Valid only for binary and infix operators; Operator precedence.

--- a/include/muParserDLL.h
+++ b/include/muParserDLL.h
@@ -65,6 +65,18 @@ extern "C"
 	typedef muFloat_t(*muFun8_t)(muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
 	typedef muFloat_t(*muFun9_t)(muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
 	typedef muFloat_t(*muFun10_t)(muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	// with user data (not null)
+	typedef muFloat_t(*muFunUserData0_t)(void*);
+	typedef muFloat_t(*muFunUserData1_t)(void*, muFloat_t);
+	typedef muFloat_t(*muFunUserData2_t)(void*, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData3_t)(void*, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData4_t)(void*, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData5_t)(void*, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData6_t)(void*, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData7_t)(void*, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData8_t)(void*, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData9_t)(void*, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muFunUserData10_t)(void*, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
 
 	// Function prototypes for bulkmode functions
 	typedef muFloat_t(*muBulkFun0_t)(int, int);
@@ -78,13 +90,33 @@ extern "C"
 	typedef muFloat_t(*muBulkFun8_t)(int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
 	typedef muFloat_t(*muBulkFun9_t)(int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
 	typedef muFloat_t(*muBulkFun10_t)(int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	// with user data (not null)
+	typedef muFloat_t(*muBulkFunUserData0_t)(void*, int, int);
+	typedef muFloat_t(*muBulkFunUserData1_t)(void*, int, int, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData2_t)(void*, int, int, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData3_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData4_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData5_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData6_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData7_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData8_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData9_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muBulkFunUserData10_t)(void*, int, int, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
 
 	typedef muFloat_t(*muMultFun_t)(const muFloat_t*, muInt_t);
+	typedef muFloat_t(*muMultFunUserData_t)(void*, const muFloat_t*, muInt_t); // with user data (not null)
+
 	typedef muFloat_t(*muStrFun1_t)(const muChar_t*);
 	typedef muFloat_t(*muStrFun2_t)(const muChar_t*, muFloat_t);
 	typedef muFloat_t(*muStrFun3_t)(const muChar_t*, muFloat_t, muFloat_t);
 	typedef muFloat_t(*muStrFun4_t)(const muChar_t*, muFloat_t, muFloat_t, muFloat_t);
 	typedef muFloat_t(*muStrFun5_t)(const muChar_t*, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
+	// with user data (not null)
+	typedef muFloat_t(*muStrFunUserData1_t)(void*, const muChar_t*);
+	typedef muFloat_t(*muStrFunUserData2_t)(void*, const muChar_t*, muFloat_t);
+	typedef muFloat_t(*muStrFunUserData3_t)(void*, const muChar_t*, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muStrFunUserData4_t)(void*, const muChar_t*, muFloat_t, muFloat_t, muFloat_t);
+	typedef muFloat_t(*muStrFunUserData5_t)(void*, const muChar_t*, muFloat_t, muFloat_t, muFloat_t, muFloat_t);
 
 	// Functions for parser management
 	typedef void (*muErrorHandler_t)(muParserHandle_t a_hParser);           // [optional] callback to an error handler
@@ -131,6 +163,18 @@ extern "C"
 	API_EXPORT(void) mupDefineFun8(muParserHandle_t a_hParser, const muChar_t* a_szName, muFun8_t a_pFun, muBool_t a_bOptimize);
 	API_EXPORT(void) mupDefineFun9(muParserHandle_t a_hParser, const muChar_t* a_szName, muFun9_t a_pFun, muBool_t a_bOptimize);
 	API_EXPORT(void) mupDefineFun10(muParserHandle_t a_hParser, const muChar_t* a_szName, muFun10_t a_pFun, muBool_t a_bOptimize);
+	// with user data (not null)
+	API_EXPORT(void) mupDefineFunUserData0(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData0_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData1(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData1_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData2(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData2_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData3(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData3_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData4(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData4_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData5(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData5_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData6(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData6_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData7(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData7_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData8(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData8_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData9(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData9_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
+	API_EXPORT(void) mupDefineFunUserData10(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData10_t a_pFun, void* a_pUserData, muBool_t a_bOptimize);
 
 	// Defining bulkmode functions
 	API_EXPORT(void) mupDefineBulkFun0(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFun0_t a_pFun);
@@ -144,6 +188,18 @@ extern "C"
 	API_EXPORT(void) mupDefineBulkFun8(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFun8_t a_pFun);
 	API_EXPORT(void) mupDefineBulkFun9(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFun9_t a_pFun);
 	API_EXPORT(void) mupDefineBulkFun10(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFun10_t a_pFun);
+	// with user data (not null)
+	API_EXPORT(void) mupDefineBulkFunUserData0(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData0_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData1(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData1_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData2(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData2_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData3(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData3_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData4(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData4_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData5(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData5_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData6(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData6_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData7(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData7_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData8(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData8_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData9(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData9_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineBulkFunUserData10(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData10_t a_pFun, void* a_pUserData);
 
 	// string functions
 	API_EXPORT(void) mupDefineStrFun1(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFun1_t a_pFun);
@@ -151,10 +207,22 @@ extern "C"
 	API_EXPORT(void) mupDefineStrFun3(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFun3_t a_pFun);
 	API_EXPORT(void) mupDefineStrFun4(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFun4_t a_pFun);
 	API_EXPORT(void) mupDefineStrFun5(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFun5_t a_pFun);
+	// with user data (not null)
+	API_EXPORT(void) mupDefineStrFunUserData1(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData1_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineStrFunUserData2(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData2_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineStrFunUserData3(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData3_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineStrFunUserData4(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData4_t a_pFun, void* a_pUserData);
+	API_EXPORT(void) mupDefineStrFunUserData5(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData5_t a_pFun, void* a_pUserData);
 
 	API_EXPORT(void) mupDefineMultFun(muParserHandle_t a_hParser,
 		const muChar_t* a_szName,
 		muMultFun_t a_pFun,
+		muBool_t a_bOptimize);
+	// with user data (not null)
+	API_EXPORT(void) mupDefineMultFunUserData(muParserHandle_t a_hParser,
+		const muChar_t* a_szName,
+		muMultFunUserData_t a_pFun,
+		void* a_pUserData,
 		muBool_t a_bOptimize);
 
 	API_EXPORT(void) mupDefineOprt(muParserHandle_t a_hParser,

--- a/include/muParserDef.h
+++ b/include/muParserDef.h
@@ -321,8 +321,8 @@ namespace mu
 
 	// Parser callbacks
 
-	/** \brief Callback type used for functions without arguments. */
-	typedef value_type(*generic_fun_type)();
+	/** \brief Function type used to erase type.  Voluntarily needs explicit cast with all other *fun_type*. */
+	typedef void(*erased_fun_type)();
 
 	/** \brief Callback type used for functions without arguments. */
 	typedef value_type(*fun_type0)();

--- a/include/muParserDef.h
+++ b/include/muParserDef.h
@@ -357,6 +357,39 @@ namespace mu
 	/** \brief Callback type used for functions with ten arguments. */
 	typedef value_type(*fun_type10)(value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
 
+	/** \brief Callback type with user data (not null) used for functions without arguments. */
+	typedef value_type(*fun_userdata_type0)(void*);
+
+	/** \brief Callback type with user data (not null) used for functions with a single arguments. */
+	typedef value_type(*fun_userdata_type1)(void*, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with two arguments. */
+	typedef value_type(*fun_userdata_type2)(void*, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with three arguments. */
+	typedef value_type(*fun_userdata_type3)(void*, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with four arguments. */
+	typedef value_type(*fun_userdata_type4)(void*, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with five arguments. */
+	typedef value_type(*fun_userdata_type5)(void*, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with six arguments. */
+	typedef value_type(*fun_userdata_type6)(void*, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with seven arguments. */
+	typedef value_type(*fun_userdata_type7)(void*, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with eight arguments. */
+	typedef value_type(*fun_userdata_type8)(void*, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with nine arguments. */
+	typedef value_type(*fun_userdata_type9)(void*, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with ten arguments. */
+	typedef value_type(*fun_userdata_type10)(void*, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
 	/** \brief Callback type used for functions without arguments. */
 	typedef value_type(*bulkfun_type0)(int, int);
 
@@ -390,8 +423,44 @@ namespace mu
 	/** \brief Callback type used for functions with ten arguments. */
 	typedef value_type(*bulkfun_type10)(int, int, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
 
+	/** \brief Callback type with user data (not null) used for functions without arguments. */
+	typedef value_type(*bulkfun_userdata_type0)(void*, int, int);
+
+	/** \brief Callback type with user data (not null) used for functions with a single arguments. */
+	typedef value_type(*bulkfun_userdata_type1)(void*, int, int, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with two arguments. */
+	typedef value_type(*bulkfun_userdata_type2)(void*, int, int, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with three arguments. */
+	typedef value_type(*bulkfun_userdata_type3)(void*, int, int, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with four arguments. */
+	typedef value_type(*bulkfun_userdata_type4)(void*, int, int, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with five arguments. */
+	typedef value_type(*bulkfun_userdata_type5)(void*, int, int, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with six arguments. */
+	typedef value_type(*bulkfun_userdata_type6)(void*, int, int, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with seven arguments. */
+	typedef value_type(*bulkfun_userdata_type7)(void*, int, int, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with eight arguments. */
+	typedef value_type(*bulkfun_userdata_type8)(void*, int, int, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with nine arguments. */
+	typedef value_type(*bulkfun_userdata_type9)(void*, int, int, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions with ten arguments. */
+	typedef value_type(*bulkfun_userdata_type10)(void*, int, int, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type, value_type);
+
 	/** \brief Callback type used for functions with a variable argument list. */
 	typedef value_type(*multfun_type)(const value_type*, int);
+
+	/** \brief Callback type with user data (not null) used for functions and a variable argument list. */
+	typedef value_type(*multfun_userdata_type)(void*, const value_type*, int);
 
 	/** \brief Callback type used for functions taking a string as an argument. */
 	typedef value_type(*strfun_type1)(const char_type*);
@@ -407,6 +476,21 @@ namespace mu
 
 	/** \brief Callback type used for functions taking a string and two values as arguments. */
 	typedef value_type(*strfun_type5)(const char_type*, value_type, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions taking a string as an argument. */
+	typedef value_type(*strfun_userdata_type1)(void*, const char_type*);
+
+	/** \brief Callback type with user data (not null) used for functions taking a string and a value as arguments. */
+	typedef value_type(*strfun_userdata_type2)(void*, const char_type*, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions taking a string and two values as arguments. */
+	typedef value_type(*strfun_userdata_type3)(void*, const char_type*, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions taking a string and a value as arguments. */
+	typedef value_type(*strfun_userdata_type4)(void*, const char_type*, value_type, value_type, value_type);
+
+	/** \brief Callback type with user data (not null) used for functions taking a string and two values as arguments. */
+	typedef value_type(*strfun_userdata_type5)(void*, const char_type*, value_type, value_type, value_type, value_type);
 
 	/** \brief Callback used for functions that identify values in a string. */
 	typedef int (*identfun_type)(const char_type* sExpr, int* nPos, value_type* fVal);

--- a/include/muParserTest.h
+++ b/include/muParserTest.h
@@ -31,6 +31,7 @@
 
 #include <string>
 #include <cstdlib>
+#include <cstdint>
 #include <numeric> // for accumulate
 #include "muParser.h"
 #include "muParserInt.h"
@@ -184,6 +185,31 @@ namespace mu
 
 			// Custom value recognition
 			static int IsHexVal(const char_type* a_szExpr, int* a_iPos, value_type* a_fVal);
+
+			// With user data
+			static value_type FunUd0(void* data) { return reinterpret_cast<std::intptr_t>(data); }
+			static value_type FunUd1(void* data, value_type v) { return reinterpret_cast<std::intptr_t>(data) + v; }
+			static value_type FunUd2(void* data, value_type v1, value_type v2) { return reinterpret_cast<std::intptr_t>(data) + v1 + v2; }
+			static value_type FunUd10(void* data, value_type v1, value_type v2, value_type v3, value_type v4, value_type v5,
+			                                      value_type v6, value_type v7, value_type v8, value_type v9, value_type v10)
+			{
+				return reinterpret_cast<std::intptr_t>(data) + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 + v9 + v10;
+			}
+			static value_type StrFunUd3(void* data, const char_type* v1, value_type v2, value_type v3)
+			{
+				int val(0);
+				stringstream_type(v1) >> val;
+				return reinterpret_cast<std::intptr_t>(data) + val + v2 + v3;
+			}
+			static value_type SumUd(void* data, const value_type* a_afArg, int a_iArgc)
+			{
+				if (!a_iArgc)
+					throw mu::Parser::exception_type(_T("too few arguments for function sum."));
+
+				value_type fRes = 0;
+				for (int i = 0; i < a_iArgc; ++i) fRes += a_afArg[i];
+				return reinterpret_cast<std::intptr_t>(data) + fRes;
+			}
 
 			int TestNames();
 			int TestSyntax();

--- a/include/muParserToken.h
+++ b/include/muParserToken.h
@@ -52,55 +52,76 @@
 namespace mu
 {
 	template <std::size_t NbParams> struct TplCallType;
-	template <> struct TplCallType<0> { using fun_type = fun_type0; using bulkfun_type = bulkfun_type0; };
-	template <> struct TplCallType<1> { using fun_type = fun_type1; using bulkfun_type = bulkfun_type1; using strfun_type = strfun_type1; };
-	template <> struct TplCallType<2> { using fun_type = fun_type2; using bulkfun_type = bulkfun_type2; using strfun_type = strfun_type2; };
-	template <> struct TplCallType<3> { using fun_type = fun_type3; using bulkfun_type = bulkfun_type3; using strfun_type = strfun_type3; };
-	template <> struct TplCallType<4> { using fun_type = fun_type4; using bulkfun_type = bulkfun_type4; using strfun_type = strfun_type4; };
-	template <> struct TplCallType<5> { using fun_type = fun_type5; using bulkfun_type = bulkfun_type5; using strfun_type = strfun_type5; };
-	template <> struct TplCallType<6> { using fun_type = fun_type6; using bulkfun_type = bulkfun_type6; };
-	template <> struct TplCallType<7> { using fun_type = fun_type7; using bulkfun_type = bulkfun_type7; };
-	template <> struct TplCallType<8> { using fun_type = fun_type8; using bulkfun_type = bulkfun_type8; };
-	template <> struct TplCallType<9> { using fun_type = fun_type9; using bulkfun_type = bulkfun_type9; };
-	template <> struct TplCallType<10> { using fun_type = fun_type10; using bulkfun_type = bulkfun_type10; };
+	template <> struct TplCallType<0> { using fun_type = fun_type0; using fun_userdata_type = fun_userdata_type0; using bulkfun_type = bulkfun_type0; using bulkfun_userdata_type = bulkfun_userdata_type0; };
+	template <> struct TplCallType<1> { using fun_type = fun_type1; using fun_userdata_type = fun_userdata_type1; using bulkfun_type = bulkfun_type1; using bulkfun_userdata_type = bulkfun_userdata_type1; using strfun_type = strfun_type1; using strfun_userdata_type = strfun_userdata_type1; };
+	template <> struct TplCallType<2> { using fun_type = fun_type2; using fun_userdata_type = fun_userdata_type2; using bulkfun_type = bulkfun_type2; using bulkfun_userdata_type = bulkfun_userdata_type2; using strfun_type = strfun_type2; using strfun_userdata_type = strfun_userdata_type2; };
+	template <> struct TplCallType<3> { using fun_type = fun_type3; using fun_userdata_type = fun_userdata_type3; using bulkfun_type = bulkfun_type3; using bulkfun_userdata_type = bulkfun_userdata_type3; using strfun_type = strfun_type3; using strfun_userdata_type = strfun_userdata_type3; };
+	template <> struct TplCallType<4> { using fun_type = fun_type4; using fun_userdata_type = fun_userdata_type4; using bulkfun_type = bulkfun_type4; using bulkfun_userdata_type = bulkfun_userdata_type4; using strfun_type = strfun_type4; using strfun_userdata_type = strfun_userdata_type4; };
+	template <> struct TplCallType<5> { using fun_type = fun_type5; using fun_userdata_type = fun_userdata_type5; using bulkfun_type = bulkfun_type5; using bulkfun_userdata_type = bulkfun_userdata_type5; using strfun_type = strfun_type5; using strfun_userdata_type = strfun_userdata_type5; };
+	template <> struct TplCallType<6> { using fun_type = fun_type6; using fun_userdata_type = fun_userdata_type6; using bulkfun_type = bulkfun_type6; using bulkfun_userdata_type = bulkfun_userdata_type6; };
+	template <> struct TplCallType<7> { using fun_type = fun_type7; using fun_userdata_type = fun_userdata_type7; using bulkfun_type = bulkfun_type7; using bulkfun_userdata_type = bulkfun_userdata_type7; };
+	template <> struct TplCallType<8> { using fun_type = fun_type8; using fun_userdata_type = fun_userdata_type8; using bulkfun_type = bulkfun_type8; using bulkfun_userdata_type = bulkfun_userdata_type8; };
+	template <> struct TplCallType<9> { using fun_type = fun_type9; using fun_userdata_type = fun_userdata_type9; using bulkfun_type = bulkfun_type9; using bulkfun_userdata_type = bulkfun_userdata_type9; };
+	template <> struct TplCallType<10> { using fun_type = fun_type10; using fun_userdata_type = fun_userdata_type10; using bulkfun_type = bulkfun_type10; using bulkfun_userdata_type = bulkfun_userdata_type10; };
 
 	struct generic_callable_type
 	{
 		// Note: we keep generic_callable_type a pod for the purpose of layout
 
-		erased_fun_type	pRawFun_;
+		erased_fun_type pRawFun_;
+		void*           pUserData_;
 
 		template <std::size_t NbParams, typename... Args>
 		value_type call_fun(Args&&... args) const
 		{
 			static_assert(NbParams == sizeof...(Args), "mismatch between NbParams and Args");
-			auto fun_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::fun_type>(pRawFun_);
-			return (*fun_typed_ptr)(std::forward<Args>(args)...);
+			if (pUserData_ == nullptr) {
+				auto fun_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::fun_type>(pRawFun_);
+				return (*fun_typed_ptr)(std::forward<Args>(args)...);
+			} else {
+				auto fun_userdata_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::fun_userdata_type>(pRawFun_);
+				return (*fun_userdata_typed_ptr)(pUserData_, std::forward<Args>(args)...);
+			}
 		}
 
 		template <std::size_t NbParams, typename... Args>
 		value_type call_bulkfun(Args&&... args) const
 		{
 			static_assert(NbParams == sizeof...(Args) - 2, "mismatch between NbParams and Args");
-			auto bulkfun_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::bulkfun_type>(pRawFun_);
-			return (*bulkfun_typed_ptr)(std::forward<Args>(args)...);
+			if (pUserData_ == nullptr) {
+				auto bulkfun_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::bulkfun_type>(pRawFun_);
+				return (*bulkfun_typed_ptr)(std::forward<Args>(args)...);
+			} else {
+				auto bulkfun_userdata_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::bulkfun_userdata_type>(pRawFun_);
+				return (*bulkfun_userdata_typed_ptr)(pUserData_, std::forward<Args>(args)...);
+			}
 		}
 
 		value_type call_multfun(const value_type* a_afArg, int a_iArgc) const
 		{
-			auto multfun_typed_ptr = reinterpret_cast<multfun_type>(pRawFun_);
-			return (*multfun_typed_ptr)(a_afArg, a_iArgc);
+			if (pUserData_ == nullptr) {
+				auto multfun_typed_ptr = reinterpret_cast<multfun_type>(pRawFun_);
+				return (*multfun_typed_ptr)(a_afArg, a_iArgc);
+			} else {
+				auto multfun_userdata_typed_ptr = reinterpret_cast<multfun_userdata_type>(pRawFun_);
+				return (*multfun_userdata_typed_ptr)(pUserData_, a_afArg, a_iArgc);
+			}
 		}
 
 		template <std::size_t NbParams, typename... Args>
 		value_type call_strfun(Args&&... args) const
 		{
 			static_assert(NbParams == sizeof...(Args), "mismatch between NbParams and Args");
-			auto strfun_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::strfun_type>(pRawFun_);
-			return (*strfun_typed_ptr)(std::forward<Args>(args)...);
+			if (pUserData_ == nullptr) {
+				auto strfun_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::strfun_type>(pRawFun_);
+				return (*strfun_typed_ptr)(std::forward<Args>(args)...);
+			} else {
+				auto strfun_userdata_typed_ptr = reinterpret_cast<typename TplCallType<NbParams>::strfun_userdata_type>(pRawFun_);
+				return (*strfun_userdata_typed_ptr)(pUserData_, std::forward<Args>(args)...);
+			}
 		}
 
-		bool operator==(generic_callable_type other) const { return pRawFun_ == other.pRawFun_; }
+		bool operator==(generic_callable_type other) const { return pRawFun_ == other.pRawFun_ && pUserData_ == other.pUserData_; }
 		explicit operator bool() const { return static_cast<bool>(pRawFun_); }
 		bool operator==(std::nullptr_t) const { return pRawFun_ == nullptr; }
 		bool operator!=(std::nullptr_t) const { return pRawFun_ != nullptr; }
@@ -400,7 +421,8 @@ namespace mu
 		generic_callable_type GetFuncAddr() const
 		{
 			return (m_pCallback.get())
-				? generic_callable_type{(erased_fun_type)m_pCallback->GetAddr()}
+				? generic_callable_type{(erased_fun_type)m_pCallback->GetAddr(),
+				                        m_pCallback->GetUserData()}
 				: generic_callable_type{};
 		}
 

--- a/include/muParserToken.h
+++ b/include/muParserToken.h
@@ -122,7 +122,7 @@ namespace mu
 		}
 
 		bool operator==(generic_callable_type other) const { return pRawFun_ == other.pRawFun_ && pUserData_ == other.pUserData_; }
-		explicit operator bool() const { return static_cast<bool>(pRawFun_); }
+		explicit operator bool() const { return pRawFun_ != nullptr; }
 		bool operator==(std::nullptr_t) const { return pRawFun_ == nullptr; }
 		bool operator!=(std::nullptr_t) const { return pRawFun_ != nullptr; }
 	};

--- a/src/muParserBase.cpp
+++ b/src/muParserBase.cpp
@@ -751,7 +751,7 @@ namespace mu
 			Error(ecSTRING_EXPECTED, m_pTokenReader->GetPos(), a_FunTok.GetAsString());
 
 		token_type  valTok;
-		generic_fun_type pFunc = a_FunTok.GetFuncAddr();
+		generic_callable_type pFunc = a_FunTok.GetFuncAddr();
 		MUP_ASSERT(pFunc);
 
 		try
@@ -1055,11 +1055,11 @@ namespace mu
 
 		// numerical function without any argument
 		case cmFUNC:
-			return (*(fun_type0)tok->Fun.ptr)();
+			return tok->Fun.cb.call_fun<0>();
 
 		// String function without a numerical argument
 		case cmFUNC_STR:
-			return (*(strfun_type1)tok->Fun.ptr)(m_vStringBuf[0].c_str());
+			return tok->Fun.cb.call_strfun<1>(m_vStringBuf[0].c_str());
 
 		default:
 			throw ParserError(ecINTERNAL_ERROR);
@@ -1156,17 +1156,17 @@ namespace mu
 				// switch according to argument count
 				switch (iArgCount)
 				{
-				case 0: sidx += 1; Stack[sidx] = (*(fun_type0)pTok->Fun.ptr)(); continue;
-				case 1:            Stack[sidx] = (*(fun_type1)pTok->Fun.ptr)(Stack[sidx]);   continue;
-				case 2: sidx -= 1; Stack[sidx] = (*(fun_type2)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1]); continue;
-				case 3: sidx -= 2; Stack[sidx] = (*(fun_type3)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2]); continue;
-				case 4: sidx -= 3; Stack[sidx] = (*(fun_type4)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3]); continue;
-				case 5: sidx -= 4; Stack[sidx] = (*(fun_type5)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4]); continue;
-				case 6: sidx -= 5; Stack[sidx] = (*(fun_type6)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5]); continue;
-				case 7: sidx -= 6; Stack[sidx] = (*(fun_type7)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6]); continue;
-				case 8: sidx -= 7; Stack[sidx] = (*(fun_type8)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7]); continue;
-				case 9: sidx -= 8; Stack[sidx] = (*(fun_type9)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8]); continue;
-				case 10:sidx -= 9; Stack[sidx] = (*(fun_type10)pTok->Fun.ptr)(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8], Stack[sidx + 9]); continue;
+				case 0: sidx += 1; Stack[sidx] = pTok->Fun.cb.call_fun<0>(); continue;
+				case 1:            Stack[sidx] = pTok->Fun.cb.call_fun<1>(Stack[sidx]);   continue;
+				case 2: sidx -= 1; Stack[sidx] = pTok->Fun.cb.call_fun<2>(Stack[sidx], Stack[sidx + 1]); continue;
+				case 3: sidx -= 2; Stack[sidx] = pTok->Fun.cb.call_fun<3>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2]); continue;
+				case 4: sidx -= 3; Stack[sidx] = pTok->Fun.cb.call_fun<4>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3]); continue;
+				case 5: sidx -= 4; Stack[sidx] = pTok->Fun.cb.call_fun<5>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4]); continue;
+				case 6: sidx -= 5; Stack[sidx] = pTok->Fun.cb.call_fun<6>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5]); continue;
+				case 7: sidx -= 6; Stack[sidx] = pTok->Fun.cb.call_fun<7>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6]); continue;
+				case 8: sidx -= 7; Stack[sidx] = pTok->Fun.cb.call_fun<8>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7]); continue;
+				case 9: sidx -= 8; Stack[sidx] = pTok->Fun.cb.call_fun<9>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8]); continue;
+				case 10:sidx -= 9; Stack[sidx] = pTok->Fun.cb.call_fun<10>(Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8], Stack[sidx + 9]); continue;
 				default:
 					// function with variable arguments store the number as a negative value
 					if (iArgCount > 0)
@@ -1184,7 +1184,7 @@ namespace mu
 						Error(ecINTERNAL_ERROR, -1);
 					// </ibg>
 
-					Stack[sidx] = (*(multfun_type)pTok->Fun.ptr)(&Stack[sidx], -iArgCount);
+					Stack[sidx] = pTok->Fun.cb.call_multfun(&Stack[sidx], -iArgCount);
 					continue;
 				}
 			}
@@ -1201,11 +1201,11 @@ namespace mu
 
 				switch (pTok->Fun.argc)  // switch according to argument count
 				{
-				case 0: Stack[sidx] = (*(strfun_type1)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str()); continue;
-				case 1: Stack[sidx] = (*(strfun_type2)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx]); continue;
-				case 2: Stack[sidx] = (*(strfun_type3)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx + 1]); continue;
-				case 3: Stack[sidx] = (*(strfun_type4)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx + 1], Stack[sidx + 2]); continue;
-				case 4: Stack[sidx] = (*(strfun_type5)pTok->Fun.ptr)(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3]); continue;
+				case 0: Stack[sidx] = pTok->Fun.cb.call_strfun<1>(m_vStringBuf[iIdxStack].c_str()); continue;
+				case 1: Stack[sidx] = pTok->Fun.cb.call_strfun<2>(m_vStringBuf[iIdxStack].c_str(), Stack[sidx]); continue;
+				case 2: Stack[sidx] = pTok->Fun.cb.call_strfun<3>(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx + 1]); continue;
+				case 3: Stack[sidx] = pTok->Fun.cb.call_strfun<4>(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx + 1], Stack[sidx + 2]); continue;
+				case 4: Stack[sidx] = pTok->Fun.cb.call_strfun<5>(m_vStringBuf[iIdxStack].c_str(), Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3]); continue;
 				}
 
 				continue;
@@ -1218,17 +1218,17 @@ namespace mu
 				// switch according to argument count
 				switch (iArgCount)
 				{
-				case 0: sidx += 1; Stack[sidx] = (*(bulkfun_type0)pTok->Fun.ptr)(nOffset, nThreadID); continue;
-				case 1:            Stack[sidx] = (*(bulkfun_type1)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx]); continue;
-				case 2: sidx -= 1; Stack[sidx] = (*(bulkfun_type2)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1]); continue;
-				case 3: sidx -= 2; Stack[sidx] = (*(bulkfun_type3)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2]); continue;
-				case 4: sidx -= 3; Stack[sidx] = (*(bulkfun_type4)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3]); continue;
-				case 5: sidx -= 4; Stack[sidx] = (*(bulkfun_type5)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4]); continue;
-				case 6: sidx -= 5; Stack[sidx] = (*(bulkfun_type6)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5]); continue;
-				case 7: sidx -= 6; Stack[sidx] = (*(bulkfun_type7)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6]); continue;
-				case 8: sidx -= 7; Stack[sidx] = (*(bulkfun_type8)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7]); continue;
-				case 9: sidx -= 8; Stack[sidx] = (*(bulkfun_type9)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8]); continue;
-				case 10:sidx -= 9; Stack[sidx] = (*(bulkfun_type10)pTok->Fun.ptr)(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8], Stack[sidx + 9]); continue;
+				case 0: sidx += 1; Stack[sidx] = pTok->Fun.cb.call_bulkfun<0>(nOffset, nThreadID); continue;
+				case 1:            Stack[sidx] = pTok->Fun.cb.call_bulkfun<1>(nOffset, nThreadID, Stack[sidx]); continue;
+				case 2: sidx -= 1; Stack[sidx] = pTok->Fun.cb.call_bulkfun<2>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1]); continue;
+				case 3: sidx -= 2; Stack[sidx] = pTok->Fun.cb.call_bulkfun<3>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2]); continue;
+				case 4: sidx -= 3; Stack[sidx] = pTok->Fun.cb.call_bulkfun<4>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3]); continue;
+				case 5: sidx -= 4; Stack[sidx] = pTok->Fun.cb.call_bulkfun<5>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4]); continue;
+				case 6: sidx -= 5; Stack[sidx] = pTok->Fun.cb.call_bulkfun<6>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5]); continue;
+				case 7: sidx -= 6; Stack[sidx] = pTok->Fun.cb.call_bulkfun<7>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6]); continue;
+				case 8: sidx -= 7; Stack[sidx] = pTok->Fun.cb.call_bulkfun<8>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7]); continue;
+				case 9: sidx -= 8; Stack[sidx] = pTok->Fun.cb.call_bulkfun<9>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8]); continue;
+				case 10:sidx -= 9; Stack[sidx] = pTok->Fun.cb.call_bulkfun<10>(nOffset, nThreadID, Stack[sidx], Stack[sidx + 1], Stack[sidx + 2], Stack[sidx + 3], Stack[sidx + 4], Stack[sidx + 5], Stack[sidx + 6], Stack[sidx + 7], Stack[sidx + 8], Stack[sidx + 9]); continue;
 				default:
 					throw exception_type(ecINTERNAL_ERROR, 2, _T(""));
 				}

--- a/src/muParserBytecode.cpp
+++ b/src/muParserBytecode.cpp
@@ -380,7 +380,7 @@ namespace mu
 		if (m_bEnableOptimizer && a_iArgc > 0)
 		{
 			// <ibg 2020-06-10/> Unary Plus is a no-op
-			if (a_pFun == generic_callable_type{(erased_fun_type)&MathImpl<value_type>::UnaryPlus})
+			if (a_pFun == generic_callable_type{(erased_fun_type)&MathImpl<value_type>::UnaryPlus, nullptr})
 				return;
 
 			optimize = true;
@@ -588,6 +588,7 @@ namespace mu
 			case cmFUNC:  mu::console() << _T("CALL\t");
 				mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]");
 				mu::console() << _T("[ADDR: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.cb.pRawFun_) << _T("]");
+				mu::console() << _T("[USERDATA: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.cb.pUserData_) << _T("]");
 				mu::console() << _T("\n");
 				break;
 
@@ -595,7 +596,9 @@ namespace mu
 				mu::console() << _T("CALL STRFUNC\t");
 				mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]");
 				mu::console() << _T("[IDX:") << std::dec << m_vRPN[i].Fun.idx << _T("]");
-				mu::console() << _T("[ADDR: 0x") << reinterpret_cast<void*>(m_vRPN[i].Fun.cb.pRawFun_) << _T("]\n");
+				mu::console() << _T("[ADDR: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.cb.pRawFun_) << _T("]");
+				mu::console() << _T("[USERDATA: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.cb.pUserData_) << _T("]");
+				mu::console() << _T("\n");
 				break;
 
 			case cmLT:    mu::console() << _T("LT\n");  break;

--- a/src/muParserBytecode.cpp
+++ b/src/muParserBytecode.cpp
@@ -371,7 +371,7 @@ namespace mu
 		\param a_iArgc Number of arguments, negative numbers indicate multiarg functions.
 		\param a_pFun Pointer to function callback.
 	*/
-	void ParserByteCode::AddFun(generic_fun_type a_pFun, int a_iArgc)
+	void ParserByteCode::AddFun(generic_callable_type a_pFun, int a_iArgc)
 	{
 		std::size_t sz = m_vRPN.size();
 		bool optimize = false;
@@ -380,7 +380,7 @@ namespace mu
 		if (m_bEnableOptimizer && a_iArgc > 0)
 		{
 			// <ibg 2020-06-10/> Unary Plus is a no-op
-			if ((void*)a_pFun == (void*)&MathImpl<value_type>::UnaryPlus)
+			if (a_pFun == generic_callable_type{(erased_fun_type)&MathImpl<value_type>::UnaryPlus})
 				return;
 
 			optimize = true;
@@ -400,16 +400,16 @@ namespace mu
 			value_type val = 0;
 			switch (a_iArgc)
 			{
-			case 1:  val = (*reinterpret_cast<fun_type1>(a_pFun))(m_vRPN[sz - 1].Val.data2);   break;
-			case 2:  val = (*reinterpret_cast<fun_type2>(a_pFun))(m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 3:  val = (*reinterpret_cast<fun_type3>(a_pFun))(m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 4:  val = (*reinterpret_cast<fun_type4>(a_pFun))(m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 5:  val = (*reinterpret_cast<fun_type5>(a_pFun))(m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 6:  val = (*reinterpret_cast<fun_type6>(a_pFun))(m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 7:  val = (*reinterpret_cast<fun_type7>(a_pFun))(m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 8:  val = (*reinterpret_cast<fun_type8>(a_pFun))(m_vRPN[sz - 8].Val.data2, m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 9:  val = (*reinterpret_cast<fun_type9>(a_pFun))(m_vRPN[sz - 9].Val.data2, m_vRPN[sz - 8].Val.data2, m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
-			case 10: val = (*reinterpret_cast<fun_type10>(a_pFun))(m_vRPN[sz - 10].Val.data2, m_vRPN[sz - 9].Val.data2, m_vRPN[sz - 8].Val.data2, m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 1:  val = a_pFun.call_fun<1>(m_vRPN[sz - 1].Val.data2); break;
+			case 2:  val = a_pFun.call_fun<2>(m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 3:  val = a_pFun.call_fun<3>(m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 4:  val = a_pFun.call_fun<4>(m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 5:  val = a_pFun.call_fun<5>(m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 6:  val = a_pFun.call_fun<6>(m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 7:  val = a_pFun.call_fun<7>(m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 8:  val = a_pFun.call_fun<8>(m_vRPN[sz - 8].Val.data2, m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 9:  val = a_pFun.call_fun<9>(m_vRPN[sz - 9].Val.data2, m_vRPN[sz - 8].Val.data2, m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
+			case 10: val = a_pFun.call_fun<10>(m_vRPN[sz - 10].Val.data2, m_vRPN[sz - 9].Val.data2, m_vRPN[sz - 8].Val.data2, m_vRPN[sz - 7].Val.data2, m_vRPN[sz - 6].Val.data2, m_vRPN[sz - 5].Val.data2, m_vRPN[sz - 4].Val.data2, m_vRPN[sz - 3].Val.data2, m_vRPN[sz - 2].Val.data2, m_vRPN[sz - 1].Val.data2); break;
 			default:
 				// For now functions with unlimited number of arguments are not optimized
 				throw ParserError(ecINTERNAL_ERROR);
@@ -430,7 +430,7 @@ namespace mu
 			SToken tok;
 			tok.Cmd = cmFUNC;
 			tok.Fun.argc = a_iArgc;
-			tok.Fun.ptr = a_pFun;
+			tok.Fun.cb = a_pFun;
 			m_vRPN.push_back(tok);
 		}
 
@@ -445,7 +445,7 @@ namespace mu
 		\param a_iArgc Number of arguments, negative numbers indicate multiarg functions.
 		\param a_pFun Pointer to function callback.
 	*/
-	void ParserByteCode::AddBulkFun(generic_fun_type a_pFun, int a_iArgc)
+	void ParserByteCode::AddBulkFun(generic_callable_type a_pFun, int a_iArgc)
 	{
 		m_iStackPos = m_iStackPos - a_iArgc + 1;
 		m_iMaxStackSize = std::max(m_iMaxStackSize, (size_t)m_iStackPos);
@@ -453,7 +453,7 @@ namespace mu
 		SToken tok;
 		tok.Cmd = cmFUNC_BULK;
 		tok.Fun.argc = a_iArgc;
-		tok.Fun.ptr = a_pFun;
+		tok.Fun.cb = a_pFun;
 		m_vRPN.push_back(tok);
 	}
 
@@ -465,7 +465,7 @@ namespace mu
 		followed by a cmSTRFUNC code, the function pointer and an index into the
 		string buffer maintained by the parser.
 	*/
-	void ParserByteCode::AddStrFun(generic_fun_type a_pFun, int a_iArgc, int a_iIdx)
+	void ParserByteCode::AddStrFun(generic_callable_type a_pFun, int a_iArgc, int a_iIdx)
 	{
 		m_iStackPos = m_iStackPos - a_iArgc + 1;
 
@@ -473,7 +473,7 @@ namespace mu
 		tok.Cmd = cmFUNC_STR;
 		tok.Fun.argc = a_iArgc;
 		tok.Fun.idx = a_iIdx;
-		tok.Fun.ptr = a_pFun;
+		tok.Fun.cb = a_pFun;
 		m_vRPN.push_back(tok);
 
 		m_iMaxStackSize = std::max(m_iMaxStackSize, (size_t)m_iStackPos);
@@ -587,7 +587,7 @@ namespace mu
 
 			case cmFUNC:  mu::console() << _T("CALL\t");
 				mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]");
-				mu::console() << _T("[ADDR: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.ptr) << _T("]");
+				mu::console() << _T("[ADDR: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.cb.pRawFun_) << _T("]");
 				mu::console() << _T("\n");
 				break;
 
@@ -595,7 +595,7 @@ namespace mu
 				mu::console() << _T("CALL STRFUNC\t");
 				mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]");
 				mu::console() << _T("[IDX:") << std::dec << m_vRPN[i].Fun.idx << _T("]");
-				mu::console() << _T("[ADDR: 0x") << reinterpret_cast<void*>(m_vRPN[i].Fun.ptr) << _T("]\n");
+				mu::console() << _T("[ADDR: 0x") << reinterpret_cast<void*>(m_vRPN[i].Fun.cb.pRawFun_) << _T("]\n");
 				break;
 
 			case cmLT:    mu::console() << _T("LT\n");  break;

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -42,6 +42,13 @@ namespace mu
 {
 	static constexpr int CALLBACK_INTERNAL_VAR_ARGS         = 1 << 14;
 	static constexpr int CALLBACK_INTERNAL_FIXED_ARGS_MASK  = 0xf;
+	static constexpr int CALLBACK_INTERNAL_WITH_USER_DATA	= 1 << 13;
+
+	struct CbWithUserData
+	{
+		void*	pFun;
+		void* 	pUserData;
+	};
 
 
 	ParserCallback::ParserCallback(fun_type0 a_pFun, bool a_bAllowOpti)
@@ -190,6 +197,127 @@ namespace mu
 	{}
 
 
+	ParserCallback::ParserCallback(fun_userdata_type0 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(0 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type1 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(1 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type2 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(2 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type3 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(3 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type4 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(4 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type5 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(5 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type6 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(6 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type7 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(7 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type8 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(8 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type9 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(9 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(fun_userdata_type10 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(10 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
 	ParserCallback::ParserCallback(bulkfun_type0 a_pFun, bool a_bAllowOpti)
 		:m_pFun((void*)a_pFun)
 		, m_iArgc(0)
@@ -314,9 +442,141 @@ namespace mu
 	{}
 
 
+	ParserCallback::ParserCallback(bulkfun_userdata_type0 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(0 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type1 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(1 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type2 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(2 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type3 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(3 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type4 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(4 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type5 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(5 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type6 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(6 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type7 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(7 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type8 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(8 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type9 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(9 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(bulkfun_userdata_type10 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(10 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_BULK)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
 	ParserCallback::ParserCallback(multfun_type a_pFun, bool a_bAllowOpti)
 		:m_pFun((void*)a_pFun)
 		, m_iArgc(CALLBACK_INTERNAL_VAR_ARGS)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC)
+		, m_iType(tpDBL)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(multfun_userdata_type a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(CALLBACK_INTERNAL_VAR_ARGS | CALLBACK_INTERNAL_WITH_USER_DATA)
 		, m_iPri(-1)
 		, m_eOprtAsct(oaNONE)
 		, m_iCode(cmFUNC)
@@ -380,6 +640,61 @@ namespace mu
 	{}
 
 
+	ParserCallback::ParserCallback(strfun_userdata_type1 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(0 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_STR)
+		, m_iType(tpSTR)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(strfun_userdata_type2 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(1 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_STR)
+		, m_iType(tpSTR)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(strfun_userdata_type3 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(2 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_STR)
+		, m_iType(tpSTR)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(strfun_userdata_type4 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(3 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_STR)
+		, m_iType(tpSTR)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
+	ParserCallback::ParserCallback(strfun_userdata_type5 a_pFun, void* a_pUserData, bool a_bAllowOpti)
+		:m_pFun(new CbWithUserData{reinterpret_cast<void*>(a_pFun), a_pUserData})
+		, m_iArgc(4 | CALLBACK_INTERNAL_WITH_USER_DATA)
+		, m_iPri(-1)
+		, m_eOprtAsct(oaNONE)
+		, m_iCode(cmFUNC_STR)
+		, m_iType(tpSTR)
+		, m_bAllowOpti(a_bAllowOpti)
+	{}
+
+
 	/** \brief Default constructor.
 		\throw nothrow
 	*/
@@ -398,6 +713,7 @@ namespace mu
 		\throw nothrow
 	*/
 	ParserCallback::ParserCallback(const ParserCallback& ref)
+		:ParserCallback()
 	{
 		Assign(ref);
 	}
@@ -409,7 +725,11 @@ namespace mu
 	}
 
 
-	ParserCallback::~ParserCallback() = default;
+	ParserCallback::~ParserCallback()
+	{
+		if (m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
+			delete reinterpret_cast<CbWithUserData*>(m_pFun);
+	}
 
 
 	/** \brief Copy callback from argument.
@@ -421,7 +741,15 @@ namespace mu
 		if (this == &ref)
 			return;
 
-		m_pFun = ref.m_pFun;
+		if (m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA) {
+			delete reinterpret_cast<CbWithUserData*>(m_pFun);
+			m_pFun = nullptr;
+		}
+
+		if (ref.m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
+			m_pFun = new CbWithUserData(*reinterpret_cast<CbWithUserData*>(ref.m_pFun));
+		else
+			m_pFun = ref.m_pFun;
 		m_iArgc = ref.m_iArgc;
 		m_bAllowOpti = ref.m_bAllowOpti;
 		m_iCode = ref.m_iCode;
@@ -455,22 +783,40 @@ namespace mu
 		argument number to the right type.
 
 		\throw nothrow
-		\return #pFun
 	*/
 	void* ParserCallback::GetAddr() const
 	{
-		return m_pFun;
+		if (m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
+			return reinterpret_cast<CbWithUserData*>(m_pFun)->pFun;
+		else
+			return m_pFun;
+	}
+
+
+	/** \brief Get the user data if present, else nullptr
+
+		\throw nothrow
+	*/
+	void* ParserCallback::GetUserData() const
+	{
+		if (m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
+			return reinterpret_cast<CbWithUserData*>(m_pFun)->pUserData;
+		else
+			return nullptr;
 	}
 
 
 	/** \brief Check that the callback looks valid
 		\throw nothrow
 
-		Check that the function pointer is not null.
+		Check that the function pointer is not null,
+		and if there are user data that they are not null.
 	*/
 	bool ParserCallback::IsValid() const
 	{
-		return m_pFun != nullptr;
+		return GetAddr() != nullptr
+			&& !((m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
+			     && GetUserData() == nullptr);
 	}
 
 

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -40,6 +40,10 @@
 
 namespace mu
 {
+	static constexpr int CALLBACK_INTERNAL_VAR_ARGS         = 1 << 14;
+	static constexpr int CALLBACK_INTERNAL_FIXED_ARGS_MASK  = 0xf;
+
+
 	ParserCallback::ParserCallback(fun_type0 a_pFun, bool a_bAllowOpti)
 		:m_pFun((void*)a_pFun)
 		, m_iArgc(0)
@@ -312,7 +316,7 @@ namespace mu
 
 	ParserCallback::ParserCallback(multfun_type a_pFun, bool a_bAllowOpti)
 		:m_pFun((void*)a_pFun)
-		, m_iArgc(-1)
+		, m_iArgc(CALLBACK_INTERNAL_VAR_ARGS)
 		, m_iPri(-1)
 		, m_eOprtAsct(oaNONE)
 		, m_iCode(cmFUNC)
@@ -505,10 +509,13 @@ namespace mu
 	}
 
 
-	/** \brief Returns the number of function Arguments. */
+	/** \brief Returns the number of numeric function Arguments.
+
+	   This number is negative for functions with variable number of arguments.
+	*/
 	int ParserCallback::GetArgc() const
 	{
-		return m_iArgc;
+		return (m_iArgc & CALLBACK_INTERNAL_VAR_ARGS) ? -1 : (m_iArgc & CALLBACK_INTERNAL_FIXED_ARGS_MASK);
 	}
 } // namespace mu
 

--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -418,6 +418,105 @@ API_EXPORT(void) mupDefineFun10(muParserHandle_t a_hParser, const muChar_t* a_sz
 }
 
 
+API_EXPORT(void) mupDefineFunUserData0(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData0_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData1(muParserHandle_t a_hParser,	const muChar_t* a_szName, muFunUserData1_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData2(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData2_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData3(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData3_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData4(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData4_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData5(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData5_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData6(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData6_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData7(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData7_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData8(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData8_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData9(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData9_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineFunUserData10(muParserHandle_t a_hParser, const muChar_t* a_szName, muFunUserData10_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
 API_EXPORT(void) mupDefineBulkFun0(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFun0_t a_pFun)
 {
 	MU_TRY
@@ -517,6 +616,105 @@ API_EXPORT(void) mupDefineBulkFun10(muParserHandle_t a_hParser, const muChar_t* 
 }
 
 
+API_EXPORT(void) mupDefineBulkFunUserData0(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData0_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData1(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData1_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData2(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData2_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData3(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData3_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData4(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData4_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData5(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData5_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData6(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData6_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData7(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData7_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData8(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData8_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData9(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData9_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineBulkFunUserData10(muParserHandle_t a_hParser, const muChar_t* a_szName, muBulkFunUserData10_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
 API_EXPORT(void) mupDefineStrFun1(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFun1_t a_pFun)
 {
 	MU_TRY
@@ -562,11 +760,65 @@ API_EXPORT(void) mupDefineStrFun5(muParserHandle_t a_hParser, const muChar_t* a_
 }
 
 
+API_EXPORT(void) mupDefineStrFunUserData1(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData1_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineStrFunUserData2(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData2_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineStrFunUserData3(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData3_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineStrFunUserData4(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData4_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineStrFunUserData5(muParserHandle_t a_hParser, const muChar_t* a_szName, muStrFunUserData5_t a_pFun, void* a_pUserData)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, false);
+	MU_CATCH
+}
+
+
 API_EXPORT(void) mupDefineMultFun(muParserHandle_t a_hParser, const muChar_t* a_szName, muMultFun_t a_pFun,	muBool_t a_bAllowOpt)
 {
 	MU_TRY
 		muParser_t* const p(AsParser(a_hParser));
 		p->DefineFun(a_szName, a_pFun, a_bAllowOpt != 0);
+	MU_CATCH
+}
+
+
+API_EXPORT(void) mupDefineMultFunUserData(muParserHandle_t a_hParser, const muChar_t* a_szName, muMultFunUserData_t a_pFun, void* a_pUserData, muBool_t a_bAllowOpt)
+{
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineFunUserData(a_szName, a_pFun, a_pUserData, a_bAllowOpt != 0);
 	MU_CATCH
 }
 

--- a/src/muParserTest.cpp
+++ b/src/muParserTest.cpp
@@ -180,6 +180,9 @@ namespace mu
 			// string constants
 			iStat += EqnTest(_T("atof(str1)+atof(str2)"), 3.33, true);
 
+			// user data
+			iStat += EqnTest(_T("strfunud3_10(\"99\",1,2)"), 112, true);
+
 			if (iStat == 0)
 				mu::console() << _T("passed") << endl;
 			else
@@ -726,6 +729,18 @@ namespace mu
 			iStat += EqnTest(_T("sum(,)"), 0, false);
 			iStat += EqnTest(_T("sum(1,2,)"), 0, false);
 			iStat += EqnTest(_T("sum(,1,2)"), 0, false);
+
+			// user data
+			iStat += EqnTest(_T("funud0_8()"), 8, true);
+			iStat += EqnTest(_T("funud1_16(10)"), 26, true);
+			iStat += EqnTest(_T("funud2_24(10, 100)"), 134, true);
+			iStat += EqnTest(_T("funud10_32(1,2,3,4,5,6,7,8,9,10)"), 87, true);
+			iStat += EqnTest(_T("funud0_9()"), 9, true);
+			iStat += EqnTest(_T("funud1_17(10)"), 27, true);
+			iStat += EqnTest(_T("funud2_25(10, 100)"), 135, true);
+			iStat += EqnTest(_T("funud10_33(1,2,3,4,5,6,7,8,9,10)"), 88, true);
+			iStat += EqnTest(_T("sumud_100(1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,2)"), 124, true);
+			iStat += EqnTest(_T("sumud_100()"), 0, false);
 
 			if (iStat == 0)
 				mu::console() << _T("passed") << endl;
@@ -1390,6 +1405,18 @@ namespace mu
 				p1->DefineFun(_T("lastArg"), LastArg);
 				p1->DefineFun(_T("firstArg"), FirstArg);
 				p1->DefineFun(_T("order"), FirstArg);
+
+				// functions with user data
+				p1->DefineFunUserData(_T("funud0_8"), FunUd0, reinterpret_cast<void*>(8));
+				p1->DefineFunUserData(_T("funud1_16"), FunUd1, reinterpret_cast<void*>(16));
+				p1->DefineFunUserData(_T("funud2_24"), FunUd2, reinterpret_cast<void*>(24));
+				p1->DefineFunUserData(_T("funud10_32"), FunUd10, reinterpret_cast<void*>(32));
+				p1->DefineFunUserData(_T("funud0_9"), FunUd0, reinterpret_cast<void*>(9));
+				p1->DefineFunUserData(_T("funud1_17"), FunUd1, reinterpret_cast<void*>(17));
+				p1->DefineFunUserData(_T("funud2_25"), FunUd2, reinterpret_cast<void*>(25));
+				p1->DefineFunUserData(_T("funud10_33"), FunUd10, reinterpret_cast<void*>(33));
+				p1->DefineFunUserData(_T("strfunud3_10"), StrFunUd3, reinterpret_cast<void*>(10));
+				p1->DefineFunUserData(_T("sumud_100"), SumUd, reinterpret_cast<void*>(100));
 
 				// infix / postfix operator
 				// Note: Identifiers used here do not have any meaning 


### PR DESCRIPTION
Note: this pull request includes both my previous ones: https://github.com/beltoforion/muparser/pull/97 "muParserDLL: add StrFun4 and StrFun5 support" and https://github.com/beltoforion/muparser/pull/98 "trivial cleanup of ParserCallback & add methods"

For a big historical unpublished code base, we need user data on custom defined functions.
The present pull request proposes that, in a backward binary compatible way. I can simplify it if binary compat is not needed.
If you are not interested by the feature, can you please evaluate taking the two previous pull requests + the patch https://github.com/gknispel/muparser/commit/1a70008992d6d7bfd10b3a5d9d98027ceb61d8e2 "add mu::generic_callable_type: centralize the calls to fun_types, bulkfun_types, strfun_types, and multfun_type" ?

I'm open to any kind of feedback / alternative ideas / etc.

In any case: many thanks for muParser ! :)
