### PR TITLE
ParserCallback(fun_type1, [...]): split into two instead of using default values

### DIFF
--- a/include/muParserCallback.h
+++ b/include/muParserCallback.h
@@ -53,7 +53,8 @@ namespace mu
 	{
 	public:
 		ParserCallback(fun_type0  a_pFun, bool a_bAllowOpti);
-		ParserCallback(fun_type1  a_pFun, bool a_bAllowOpti, int a_iPrec = -1, ECmdCode a_iCode = cmFUNC);
+		ParserCallback(fun_type1  a_pFun, bool a_bAllowOpti, int a_iPrec, ECmdCode a_iCode);
+		ParserCallback(fun_type1  a_pFun, bool a_bAllowOpti);
 		ParserCallback(fun_type2  a_pFun, bool a_bAllowOpti, int a_iPrec, EOprtAssociativity a_eAssociativity);
 		ParserCallback(fun_type2  a_pFun, bool a_bAllowOpti);
 		ParserCallback(fun_type3  a_pFun, bool a_bAllowOpti);

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -73,6 +73,10 @@ namespace mu
 	{}
 
 
+	ParserCallback::ParserCallback(fun_type1 a_pFun, bool a_bAllowOpti)
+		: ParserCallback(a_pFun, a_bAllowOpti, -1, cmFUNC)
+	{}
+
 	
 	/** \brief Constructor for constructing function callbacks taking two arguments.
 		\throw nothrow


### PR DESCRIPTION
muparser could potentially inject the value of cmFUNC in application
binary code through the template method ParserBase::DefineFun called
with a fun_type1, when it invokes ParserCallback(a_pFun, a_bAllowOpt)

However, e.g. commit d59959ad2f7e5e2 ("Macros for version number and
version data replaced with static constants"), between v2.2.6.1 and
v2.3.2, switched its value from 27 to 26.

Therefore, to enhance future binary compatibility robustness (with
application code compiled after the present patch) in case of further
changes of ECmdCode, the present patch splits ParserCallback(
fun_type1, [...]) into two overloads without default values: one for
usage through ParserBase::DefineFun* by application code, and one for
internal usage by muparser.  For now (and until cmFUNC changes, if it
does) the one for internal usage remains binary compatible with the
one before this change.

Signed-off-by: Guillaume Knispel <guillaume.knispel@hologic.com>
Reviewed-by: Juan Gomez <juan.gomez@hologic.com>