### PR TITLE
cmake: also inject -D_UNICODE into muparser.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,9 @@ install(FILES
 
 # Define variables for the pkg-config file
 set(PACKAGE_NAME muparser)
+if(ENABLE_WIDE_CHAR)
+  set(PKG_CONFIG_FLAGS "-D_UNICODE")
+endif(ENABLE_WIDE_CHAR)
 configure_file(
     muparser.pc.in
     ${CMAKE_BINARY_DIR}/muparser.pc

--- a/muparser.pc.in
+++ b/muparser.pc.in
@@ -8,4 +8,4 @@ Description: Mathematical expressions parser library
 Version: @MUPARSER_VERSION@
 Requires:
 Libs: -L${libdir} -lmuparser
-Cflags: -I${includedir}
+Cflags: -I${includedir} @PKG_CONFIG_FLAGS@


### PR DESCRIPTION
If you compile muParser with wchar support and use pkg-config, the `_UNICODE` define is missing.

Assume you have a code like:
```cxx
#include <muParser.h>

int main() {
  return 0;
}

void ExpressionParser(const std::string& expression){
  std::unique_ptr<mu::Parser> parser = std::make_unique<mu::Parser>();
  parser->SetExpr(expression);
}
```

and compile it with
```
g++ `pkg-config --libs --cflags muparser` main.cpp
```

it will fails with:
```
/usr/lib/gcc/x86_64-pc-linux-gnu/11.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: /tmp/ccMowORw.o: in function `ExpressionParser(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
main.cpp:(.text+0x4d): undefined reference to `mu::ParserBase::SetExpr(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)'
collect2: error: ld returned 1 exit status
```

The attached patch fixed that.