### PR TITLE
Use OpenMP CMake target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ endif ()
 
 if(ENABLE_OPENMP)
   target_compile_definitions(muparser PRIVATE MUP_USE_OPENMP)
+  target_link_libraries(muparser PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
 if(ENABLE_WIDE_CHAR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,6 @@ option(BUILD_SHARED_LIBS "Build shared/static libs" ON)
 
 if(ENABLE_OPENMP)
     find_package(OpenMP REQUIRED)
-    set(CMAKE_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${CMAKE_CXX_FLAGS}")
-    set(CMAKE_SHARED_LIBRARY_CXX_FLAGS "${OpenMP_CXX_FLAGS} ${CMAKE_SHARED_LIBRARY_CXX_FLAGS}")
 endif()
 
 # Credit: https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake/3818084


### PR DESCRIPTION
Use the OpenMP::OpenMP_CXX target to more robustly provide access to `omp.h`. Also improves compatibility with a parent build system when embedded in a dependent project.