### PR TITLE
Fix problem with IntelLLVM fast math

### DIFF
--- a/src/muParserTest.cpp
+++ b/src/muParserTest.cpp
@@ -1549,17 +1549,7 @@ namespace mu
 					// The tests equations never result in infinity, if they do thats a bug.
 					// reference:
 					// http://sourceforge.net/projects/muparser/forums/forum/462843/topic/5037825
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable:4127)
-#endif
-					if (std::numeric_limits<value_type>::has_infinity)
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-					{
-						bCloseEnough &= (fabs(fVal[i]) != numeric_limits<value_type>::infinity());
-					}
+					bCloseEnough &= std::isfinite(fVal[i]);
 				}
 
 				iRet = ((bCloseEnough && a_fPass) || (!bCloseEnough && !a_fPass)) ? 0 : 1;


### PR DESCRIPTION
We found a warning while transitioning from the classic Intel compiler `icpc` to the new IntelLLVM compiler `icpx` that occurs in fast math mode. See also https://github.com/dealii/dealii/issues/15301.
```
/muparser_v2_3_3/src/muParserTest.cpp:1558:38: error: explicit comparison with infinity in fast floating point mode [-Werror,-Wtautological-constant-compare]
                                                bCloseEnough &= (fabs(fVal[i]) != numeric_limits<value_type>::infinity());
                                                                 ~~~~~~~~~~~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

The following patch suggests to use `std::isfinite` rather than a comparison with infinity. We can confirm that the warning no longer shows up.

The classic Intel compiler will be retired later in 2023.