### PR TITLE
missing dll macro for ParserTokenReader class for Windows builds

### DIFF
--- a/include/muParserTokenReader.h
+++ b/include/muParserTokenReader.h
@@ -51,7 +51,7 @@ namespace mu
 	class ParserBase;
 
 	/** \brief Token reader for the ParserBase class. */
-	class ParserTokenReader final
+	class API_EXPORT_CXX ParserTokenReader final
 	{
 	private:
 


### PR DESCRIPTION
Fixes `undefined reference to `mu::ParserTokenReader::ParserTokenReader(mu::ParserBase*)'` in Windows builds.