### PR TITLE
Opt-out of std::locale via cmake -DENABLE_LOCALE=N

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ set(MUPARSER_VERSION ${MUPARSER_VERSION_MAJOR}.${MUPARSER_VERSION_MINOR}.${MUPAR
 
 # Build options
 option(ENABLE_SAMPLES "Build the samples" ON)
+option(ENABLE_LOCALE "Enable std::locale support" ON)
 option(ENABLE_OPENMP "Enable OpenMP for multithreading" ON)
 option(ENABLE_WIDE_CHAR "Enable wide character support" OFF)
 option(BUILD_SHARED_LIBS "Build shared/static libs" ON)
@@ -70,6 +71,12 @@ endif()
 
 if(ENABLE_WIDE_CHAR)
   target_compile_definitions(muparser PUBLIC _UNICODE)
+endif()
+
+if(ENABLE_LOCALE)
+else()
+  target_compile_definitions(muparser PUBLIC MUPARSER_NO_LOCALE)
+  add_definitions( -DMUPARSER_NO_LOCALE )
 endif()
 
 set_target_properties(muparser PROPERTIES

--- a/include/muParserBase.h
+++ b/include/muParserBase.h
@@ -35,8 +35,11 @@
 #include <iostream>
 #include <map>
 #include <memory>
-#include <locale>
 #include <limits.h>
+
+#if !defined(MUPARSER_NO_LOCALE)
+#include <locale>
+#endif
 
 //--- Parser includes --------------------------------------------------------------------------
 #include "muParserDef.h"
@@ -119,9 +122,11 @@ namespace mu
 		void SetExpr(const string_type& a_sExpr);
 		void SetVarFactory(facfun_type a_pFactory, void* pUserData = nullptr);
 
+#if !defined(MUPARSER_NO_LOCALE)
 		void SetDecSep(char_type cDecSep);
 		void SetThousandsSep(char_type cThousandsSep = 0);
 		void ResetLocale();
+#endif
 
 		void EnableOptimizer(bool a_bIsOn = true);
 		void EnableBuiltInOprt(bool a_bIsOn = true);
@@ -205,7 +210,9 @@ namespace mu
 		virtual void OnDetectVar(string_type* pExpr, int& nStart, int& nEnd);
 
 		static const char_type* c_DefaultOprt[];
+#if !defined(MUPARSER_NO_LOCALE)
 		static std::locale s_locale;  ///< The locale used by the parser
+#endif
 		static bool g_DbgDumpCmdCode;
 		static bool g_DbgDumpStack;
 

--- a/src/muParser.cpp
+++ b/src/muParser.cpp
@@ -75,7 +75,9 @@ namespace mu
 
 		stringstream_type stream(a_szExpr);
 		stream.seekg(0);        // todo:  check if this really is necessary
+#if !defined(MUPARSER_NO_LOCALE)
 		stream.imbue(Parser::s_locale);
+#endif
 		stream >> fVal;
 		stringstream_type::pos_type iEnd = stream.tellg(); // Position after reading
 

--- a/src/muParserBase.cpp
+++ b/src/muParserBase.cpp
@@ -36,9 +36,12 @@
 #include <vector>
 #include <deque>
 #include <sstream>
-#include <locale>
 #include <cassert>
 #include <cctype>
+
+#if !defined(MUPARSER_NO_LOCALE)
+#include <locale>
+#endif
 
 #ifdef MUP_USE_OPENMP
 
@@ -59,7 +62,9 @@ using namespace std;
 
 namespace mu
 {
+#if !defined(MUPARSER_NO_LOCALE)
 	std::locale ParserBase::s_locale = std::locale(std::locale::classic(), new change_dec_sep<char_type>('.'));
+#endif
 
 	bool ParserBase::g_DbgDumpCmdCode = false;
 	bool ParserBase::g_DbgDumpStack = false;
@@ -193,6 +198,7 @@ namespace mu
 		m_sInfixOprtChars = a_Parser.m_sInfixOprtChars;
 	}
 
+#if !defined(MUPARSER_NO_LOCALE)
 	//---------------------------------------------------------------------------
 	/** \brief Set the decimal separator.
 		\param cDecSep Decimal separator as a character value.
@@ -232,6 +238,7 @@ namespace mu
 		s_locale = std::locale(std::locale("C"), new change_dec_sep<char_type>('.'));
 		SetArgSep(',');
 	}
+#endif
 
 	//---------------------------------------------------------------------------
 	/** \brief Initialize the token reader.
@@ -440,9 +447,11 @@ namespace mu
 	*/
 	void ParserBase::SetExpr(const string_type& a_sExpr)
 	{
+#if !defined(MUPARSER_NO_LOCALE)
 		// Check locale compatibility
 		if (m_pTokenReader->GetArgSep() == std::use_facet<numpunct<char_type> >(s_locale).decimal_point())
 			Error(ecLOCALE);
+#endif
 
 		// Check maximum allowed expression length. An arbitrary value small enough so i can debug expressions sent to me
 		if (a_sExpr.length() >= MaxLenExpression)

--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -1093,6 +1093,7 @@ API_EXPORT(void) mupSetArgSep(muParserHandle_t a_hParser, const muChar_t cArgSep
 }
 
 
+#if !defined(MUPARSER_NO_LOCALE)
 API_EXPORT(void) mupResetLocale(muParserHandle_t a_hParser)
 {
 	MU_TRY
@@ -1118,6 +1119,7 @@ API_EXPORT(void) mupSetThousandsSep(muParserHandle_t a_hParser, const muChar_t c
 		p->SetThousandsSep(cThousandsSep);
 	MU_CATCH
 }
+#endif
 
 //---------------------------------------------------------------------------
 /** \brief Retrieve name and value of a single parser constant.


### PR DESCRIPTION
Thanks for muparser, it's getting the job done nicely.

I don't have at hand the details of _why_ we needed to opt-out of std::locale, but this is the main divergence we have.