### PR TITLE
Include <algorithm> in muParserTemplateMagic.h

### DIFF
--- a/include/muParserTemplateMagic.h
+++ b/include/muParserTemplateMagic.h
@@ -29,6 +29,7 @@
 #ifndef MU_PARSER_TEMPLATE_MAGIC_H
 #define MU_PARSER_TEMPLATE_MAGIC_H
 
+#include <algorithm>
 #include <cmath>
 #include "muParserError.h"
 


### PR DESCRIPTION
The NEC compiler (https://sxauroratsubasa.sakura.ne.jp/Documentation) complains that std::min is not known here. Adding the include for algorithm, where it is defined (https://en.cppreference.com/w/cpp/algorithm/min) resolves the issue and lets muParser successfully compile with it.