### PR TITLE
Simplify OpenMP clause to avoid compiler bugs

### DIFF
--- a/src/muParserBase.cpp
+++ b/src/muParserBase.cpp
@@ -1903,7 +1903,8 @@ namespace mu
 #endif
 		omp_set_num_threads(nMaxThreads);
 
-#pragma omp parallel for schedule(static, std::max(nBulkSize/nMaxThreads, 1)) private(nThreadID)
+		const int chunkSize = std::max(nBulkSize/nMaxThreads, 1);
+#pragma omp parallel for schedule(static, chunkSize) private(nThreadID)
 		for (i = 0; i < nBulkSize; ++i)
 		{
 			nThreadID = omp_get_thread_num();


### PR DESCRIPTION
Issues were encountered when using NVC++ compiler and ScoreP wrapper. Those are compiler bugs, but extracting the chunk size not only avoids the problem, but also makes the code (subjectively) easier to read.