### PR TITLE
Only detect OpenMP flags for C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(ENABLE_WIDE_CHAR "Enable wide character support" OFF)
 option(BUILD_SHARED_LIBS "Build shared/static libs" ON)
 
 if(ENABLE_OPENMP)
-    find_package(OpenMP REQUIRED)
+    find_package(OpenMP REQUIRED COMPONENTS CXX)
 endif()
 
 # Credit: https://stackoverflow.com/questions/2368811/how-to-set-warning-level-in-cmake/3818084


### PR DESCRIPTION
By default, `find_package(OpenMP)` will run detection for all enabled languages. This is slightly wasteful since only C++ flags are needed, and can cause troubles when muParser is bundled in a project which has other languages enabled but their OpenMP support is broken.