### PR TITLE
Add input validation and error handling for arithmetic operations

### DIFF
--- a/src/muParserBase.cpp
+++ b/src/muParserBase.cpp
@@ -1100,6 +1100,8 @@ namespace mu
 
 		// String function without a numerical argument
 		case cmFUNC_STR:
+			if (m_vStringBuf.empty())
+				throw ParserError(ecINTERNAL_ERROR);
 			return tok->Fun.cb.call_strfun<1>(m_vStringBuf[0].c_str());
 
 		default:

--- a/src/muParserInt.cpp
+++ b/src/muParserInt.cpp
@@ -47,10 +47,35 @@ namespace mu
 	value_type ParserInt::Add(value_type v1, value_type v2) { return Round(v1) + Round(v2); }
 	value_type ParserInt::Sub(value_type v1, value_type v2) { return Round(v1) - Round(v2); }
 	value_type ParserInt::Mul(value_type v1, value_type v2) { return Round(v1) * Round(v2); }
-	value_type ParserInt::Div(value_type v1, value_type v2) { return Round(v1) / Round(v2); }
-	value_type ParserInt::Mod(value_type v1, value_type v2) { return Round(v1) % Round(v2); }
-	value_type ParserInt::Shr(value_type v1, value_type v2) { return Round(v1) >> Round(v2); }
-	value_type ParserInt::Shl(value_type v1, value_type v2) { return Round(v1) << Round(v2); }
+	value_type ParserInt::Div(value_type v1, value_type v2)
+	{
+		if (Round(v2) == 0)
+			throw ParserError(ecDIV_BY_ZERO);
+		return Round(v1) / Round(v2);
+	}
+
+	value_type ParserInt::Mod(value_type v1, value_type v2)
+	{
+		if (Round(v2) == 0)
+			throw ParserError(ecDIV_BY_ZERO);
+		return Round(v1) % Round(v2);
+	}
+
+	value_type ParserInt::Shr(value_type v1, value_type v2)
+	{
+		int shift = Round(v2);
+		if (shift < 0 || shift >= (int)(sizeof(int) * 8))
+			throw ParserError(ecDOMAIN_ERROR);
+		return Round(v1) >> shift;
+	}
+
+	value_type ParserInt::Shl(value_type v1, value_type v2)
+	{
+		int shift = Round(v2);
+		if (shift < 0 || shift >= (int)(sizeof(int) * 8))
+			throw ParserError(ecDOMAIN_ERROR);
+		return Round(v1) << shift;
+	}
 	value_type ParserInt::BitAnd(value_type v1, value_type v2) { return Round(v1) & Round(v2); }
 	value_type ParserInt::BitOr(value_type v1, value_type v2) { return Round(v1) | Round(v2); }
 	value_type ParserInt::And(value_type v1, value_type v2) { return Round(v1) && Round(v2); }

--- a/src/muParserTokenReader.cpp
+++ b/src/muParserTokenReader.cpp
@@ -939,10 +939,10 @@ namespace mu
 		string_type strBuf(&m_strFormula[(std::size_t)m_iPos + 1]);
 		std::size_t iEnd(0), iSkip(0);
 
-		// parser over escaped '\"' end replace them with '"'
-		for (iEnd = (int)strBuf.find(_T('\"')); iEnd != 0 && iEnd != string_type::npos; iEnd = (int)strBuf.find(_T('\"'), iEnd))
+		// parse over escaped '\"' and replace them with '"'
+		for (iEnd = strBuf.find(_T('\"')); iEnd != string_type::npos; iEnd = strBuf.find(_T('\"'), iEnd))
 		{
-			if (strBuf[iEnd - 1] != '\\') break;
+			if (iEnd == 0 || strBuf[iEnd - 1] != '\\') break;
 			strBuf.replace(iEnd - 1, 2, _T("\""));
 			iSkip++;
 		}


### PR DESCRIPTION
## Summary
This PR adds comprehensive input validation and error handling to the muParser library, preventing undefined behavior and runtime errors in arithmetic and bitwise operations.

## Key Changes

- **Division and Modulo Operations**: Added zero-divisor checks in `Div()` and `Mod()` methods that throw `ecDIV_BY_ZERO` error when attempting to divide by zero.

- **Bitwise Shift Operations**: Added validation in `Shr()` and `Shl()` methods to ensure shift amounts are non-negative and within valid range (0 to bit-width of integer), throwing `ecDOMAIN_ERROR` for invalid shifts.

- **String Parsing**: Fixed escaped quote handling in `ParserTokenReader` by:
  - Correcting the loop condition to properly detect end of string
  - Adding boundary check to prevent out-of-bounds access when checking for escape character
  - Fixed typo in comment ("parser" → "parse")

- **String Function Safety**: Added null-check guard in `ParserBase` to verify string buffer is not empty before accessing string function callbacks, throwing `ecINTERNAL_ERROR` if violated.

## Implementation Details
All validation checks are performed after rounding operands to integers, ensuring consistent behavior with the integer parser's semantics. Error handling uses the existing `ParserError` exception mechanism with appropriate error codes.

https://claude.ai/code/session_016KXvkxJZuDqp6pt2AJJVsz