### PR TITLE
Fix #168: ClearConst() does not clear m_vStringVarBuf

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,6 +28,11 @@ Rev 2.3.6: 07.03.2026
   Fixes:
    * Fix for #167 (https://github.com/beltoforion/muparser/pull/167):
      Added additional range checks for accessing internal value stack.
+   * Fix for #168 (https://github.com/beltoforion/muparser/pull/169):
+     ClearConst() now also clears m_vStringVarBuf to keep it in sync
+     with m_StrVarDef. Previously, repeated calls to ClearConst()
+     followed by DefineStrConst() caused stale entries to accumulate
+     in the string value buffer.
 
 
 Rev 2.3.5: 13.12.2024

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Change Notes for Revision 2.3.6 (2026-04-10)
   Security Fixes:
   -----------
   - Issue https://github.com/beltoforion/muparser/issues/167: Add additional checks to eliminate possibility of access violations due to malformed expressions. I dont have test cases and do not know whether this issue was exploitable at all but fixing them made sense.
+  - Issue https://github.com/beltoforion/muparser/issues/168: ClearConst() now also clears the internal string variable buffer (m_vStringVarBuf) to keep it in sync with the name-to-index map (m_StrVarDef). Previously stale entries accumulated across repeated ClearConst() calls.
 
   Fixed Compiler Warnings and Errors:
   -----------

--- a/include/muParserTest.h
+++ b/include/muParserTest.h
@@ -267,7 +267,8 @@ namespace mu
 			int TestOptimizer();
 			int TestLocalization();
 			int TestIssue165();
-			
+			int TestClearConst();
+
 			void Abort() const;
 
 		public:

--- a/include/muParserTest.h
+++ b/include/muParserTest.h
@@ -267,7 +267,7 @@ namespace mu
 			int TestOptimizer();
 			int TestLocalization();
 			int TestIssue165();
-			int TestClearConst();
+			int TestIssue168();
 
 			void Abort() const;
 

--- a/src/muParserBase.cpp
+++ b/src/muParserBase.cpp
@@ -1637,6 +1637,7 @@ namespace mu
 	{
 		m_ConstDef.clear();
 		m_StrVarDef.clear();
+		m_vStringVarBuf.clear();
 		ReInit();
 	}
 

--- a/src/muParserTest.cpp
+++ b/src/muParserTest.cpp
@@ -65,7 +65,7 @@ namespace mu
 			AddTest(&ParserTester::TestOptimizer);
 			AddTest(&ParserTester::TestLocalization);
 			AddTest(&ParserTester::TestIssue165);
-		AddTest(&ParserTester::TestClearConst);
+		AddTest(&ParserTester::TestIssue168);
 
 			ParserTester::c_iCount = 0;
 		}
@@ -1759,12 +1759,12 @@ namespace mu
 		// the value buffer silently accumulates stale entries across calls.  After
 		// one round of DefineStrConst + ClearConst + DefineStrConst the buffer
 		// should have 2 entries (not 4).  This test will FAIL until the bug is fixed.
-		int ParserTester::TestClearConst()
+		int ParserTester::TestIssue168()
 		{
 			ParserTester::c_iCount++;
 			int iRet(0);
 
-			mu::console() << _T("testing ClearConst consistency...");
+			mu::console() << _T("testing github issue 168...");
 
 			try
 			{

--- a/src/muParserTest.cpp
+++ b/src/muParserTest.cpp
@@ -65,6 +65,7 @@ namespace mu
 			AddTest(&ParserTester::TestOptimizer);
 			AddTest(&ParserTester::TestLocalization);
 			AddTest(&ParserTester::TestIssue165);
+		AddTest(&ParserTester::TestClearConst);
 
 			ParserTester::c_iCount = 0;
 		}
@@ -1746,6 +1747,73 @@ namespace mu
 			{
 				mu::console() << _T("\n  fail: unexpected exception");
 				return 1;  // exceptions other than ParserException are not allowed
+			}
+
+			return iRet;
+		}
+
+		//---------------------------------------------------------------------------
+		// Regression test for the inconsistency between m_StrVarDef and
+		// m_vStringVarBuf after ClearConst().
+		//
+		// ClearConst() clears m_StrVarDef but does NOT clear m_vStringVarBuf,
+		// so after N round-trips the value buffer holds 2*N stale entries while
+		// the map only tracks the most-recently-added indices.  Any code path
+		// that reads an index from the map and indexes into the buffer without a
+		// proper bounds check (item->second >= m_vStringVarBuf.size()) would be
+		// silently bypassed by the existing guard (!m_vStringVarBuf.size()).
+		int ParserTester::TestClearConst()
+		{
+			ParserTester::c_iCount++;
+			int iRet(0);
+
+			mu::console() << _T("testing ClearConst consistency...");
+
+			try
+			{
+				Parser p;
+				p.DefineFun(_T("strlen"), StrLen);
+
+				// Round 1: define two string constants and evaluate.
+				p.DefineStrConst(_T("s1"), _T("hello"));
+				p.DefineStrConst(_T("s2"), _T("world"));
+				p.SetExpr(_T("strlen(s1)+strlen(s2)"));
+				value_type r1 = p.Eval();   // 5+5 = 10
+
+				if (r1 != 10)
+				{
+					mu::console() << _T("\n  fail: round 1 result should be 10, got ") << r1;
+					iRet++;
+				}
+
+				// ClearConst wipes m_StrVarDef but leaves m_vStringVarBuf with
+				// the two entries from round 1 still in place.
+				p.ClearConst();
+
+				// Round 2: re-register the same names with different values.
+				// m_vStringVarBuf now has 4 entries; the map points at indices 2 and 3.
+				p.DefineStrConst(_T("s1"), _T("hi"));
+				p.DefineStrConst(_T("s2"), _T("!"));
+				p.SetExpr(_T("strlen(s1)+strlen(s2)"));
+				value_type r2 = p.Eval();   // 2+1 = 3
+
+				if (r2 != 3)
+				{
+					// If the bug were present and the index wrapped or pointed at a
+					// stale entry, we'd get the old lengths (5+5=10) instead of 3.
+					mu::console() << _T("\n  fail: round 2 result should be 3, got ") << r2;
+					iRet++;
+				}
+
+				if (iRet == 0)
+					mu::console() << _T("passed") << endl;
+				else
+					mu::console() << _T("\n  failed with ") << iRet << _T(" errors") << endl;
+			}
+			catch (...)
+			{
+				mu::console() << _T("\n  fail: unexpected exception");
+				return 1;
 			}
 
 			return iRet;

--- a/src/muParserTest.cpp
+++ b/src/muParserTest.cpp
@@ -1753,15 +1753,12 @@ namespace mu
 		}
 
 		//---------------------------------------------------------------------------
-		// Regression test for the inconsistency between m_StrVarDef and
-		// m_vStringVarBuf after ClearConst().
+		// Regression test: ClearConst() must also clear m_vStringVarBuf.
 		//
-		// ClearConst() clears m_StrVarDef but does NOT clear m_vStringVarBuf,
-		// so after N round-trips the value buffer holds 2*N stale entries while
-		// the map only tracks the most-recently-added indices.  Any code path
-		// that reads an index from the map and indexes into the buffer without a
-		// proper bounds check (item->second >= m_vStringVarBuf.size()) would be
-		// silently bypassed by the existing guard (!m_vStringVarBuf.size()).
+		// Currently ClearConst() clears m_StrVarDef but not m_vStringVarBuf, so
+		// the value buffer silently accumulates stale entries across calls.  After
+		// one round of DefineStrConst + ClearConst + DefineStrConst the buffer
+		// should have 2 entries (not 4).  This test will FAIL until the bug is fixed.
 		int ParserTester::TestClearConst()
 		{
 			ParserTester::c_iCount++;
@@ -1774,34 +1771,25 @@ namespace mu
 				Parser p;
 				p.DefineFun(_T("strlen"), StrLen);
 
-				// Round 1: define two string constants and evaluate.
 				p.DefineStrConst(_T("s1"), _T("hello"));
 				p.DefineStrConst(_T("s2"), _T("world"));
 				p.SetExpr(_T("strlen(s1)+strlen(s2)"));
-				value_type r1 = p.Eval();   // 5+5 = 10
+				p.Eval();
 
-				if (r1 != 10)
-				{
-					mu::console() << _T("\n  fail: round 1 result should be 10, got ") << r1;
-					iRet++;
-				}
-
-				// ClearConst wipes m_StrVarDef but leaves m_vStringVarBuf with
-				// the two entries from round 1 still in place.
 				p.ClearConst();
 
-				// Round 2: re-register the same names with different values.
-				// m_vStringVarBuf now has 4 entries; the map points at indices 2 and 3.
 				p.DefineStrConst(_T("s1"), _T("hi"));
 				p.DefineStrConst(_T("s2"), _T("!"));
 				p.SetExpr(_T("strlen(s1)+strlen(s2)"));
-				value_type r2 = p.Eval();   // 2+1 = 3
+				p.Eval();
 
-				if (r2 != 3)
+				// After ClearConst + re-registration the buffer should hold exactly
+				// 2 entries.  If ClearConst does not clear it, the buffer has 4.
+				std::size_t sz = p.m_vStringVarBuf.size();
+				if (sz != 2)
 				{
-					// If the bug were present and the index wrapped or pointed at a
-					// stale entry, we'd get the old lengths (5+5=10) instead of 3.
-					mu::console() << _T("\n  fail: round 2 result should be 3, got ") << r2;
+					mu::console() << _T("\n  fail: m_vStringVarBuf.size() == ") << sz
+					              << _T(" (expected 2 — ClearConst does not clear the buffer)");
 					iRet++;
 				}
 


### PR DESCRIPTION
Fixes #168.

## Problem

`ClearConst()` cleared `m_StrVarDef` (the name→index map) but not `m_vStringVarBuf` (the string value buffer). After each round of `DefineStrConst` + `ClearConst` + `DefineStrConst` the buffer accumulated stale entries, leaving the two structures out of sync.

## Fix

One line added to `ClearConst()` in `muParserBase.cpp`:

```cpp
m_vStringVarBuf.clear();
```

## Test

`TestIssue168` in `muParserTest.cpp` verifies that after `ClearConst()` + re-registration, `m_vStringVarBuf.size()` equals the number of newly registered constants (2), not the accumulated total (4). The test failed before this fix and passes after.
