### PR TITLE
Fix 14 bugs in /src: memory safety, UB, logic errors, thread safety

### DIFF
--- a/src/muParserBase.cpp
+++ b/src/muParserBase.cpp
@@ -1076,21 +1076,31 @@ namespace mu
 		case cmVAL:		
 			return tok->Val.data2;
 
-		case cmVAR:		
+		case cmVAR:
+			if (!tok->Val.ptr)
+				throw ParserError(ecINVALID_VAR_PTR);
 			return *tok->Val.ptr;
 
-		case cmVARMUL:	
+		case cmVARMUL:
+			if (!tok->Val.ptr)
+				throw ParserError(ecINVALID_VAR_PTR);
 			return *tok->Val.ptr * tok->Val.data + tok->Val.data2;
 
-		case cmVARPOW2: 
+		case cmVARPOW2:
+			if (!tok->Val.ptr)
+				throw ParserError(ecINVALID_VAR_PTR);
 			buf = *(tok->Val.ptr);
 			return buf * buf;
 
-		case  cmVARPOW3: 				
+		case  cmVARPOW3:
+			if (!tok->Val.ptr)
+				throw ParserError(ecINVALID_VAR_PTR);
 			buf = *(tok->Val.ptr);
 			return buf * buf * buf;
 
-		case  cmVARPOW4: 				
+		case  cmVARPOW4:
+			if (!tok->Val.ptr)
+				throw ParserError(ecINVALID_VAR_PTR);
 			buf = *(tok->Val.ptr);
 			return buf * buf * buf * buf;
 

--- a/src/muParserBytecode.cpp
+++ b/src/muParserBytecode.cpp
@@ -172,6 +172,8 @@ namespace mu
 		case cmSUB:  x = x - y;  m_vRPN.pop_back();  break;
 		case cmMUL:  x = x * y;  m_vRPN.pop_back();  break;
 		case cmDIV:
+			if (y == 0)
+				break;
 			x = x / y;
 			m_vRPN.pop_back();
 			break;
@@ -509,12 +511,16 @@ namespace mu
 
 			case cmELSE:
 				stElse.push(i);
+				if (stIf.empty())
+					throw ParserError(ecINTERNAL_ERROR);
 				idx = stIf.top();
 				stIf.pop();
 				m_vRPN[idx].Oprt.offset = i - idx;
 				break;
 
 			case cmENDIF:
+				if (stElse.empty())
+					throw ParserError(ecINTERNAL_ERROR);
 				idx = stElse.top();
 				stElse.pop();
 				m_vRPN[idx].Oprt.offset = i - idx;
@@ -601,10 +607,13 @@ namespace mu
 				mu::console() << _T("CALL STRFUNC\t");
 				mu::console() << _T("[ARG:") << std::dec << m_vRPN[i].Fun.argc << _T("]");
 
-				if (i<0 || i >= m_stringBuffer.size())
-					throw ParserError(ecINTERNAL_ERROR);
+				{
+					int idx = m_vRPN[i].Fun.idx;
+					if (idx < 0 || idx >= (int)m_stringBuffer.size())
+						throw ParserError(ecINTERNAL_ERROR);
 
-				mu::console() << _T("[IDX:") << std::dec << m_vRPN[i].Fun.idx << _T("=\"") << m_stringBuffer[m_vRPN[i].Fun.idx] << ("\"]");
+					mu::console() << _T("[IDX:") << std::dec << idx << _T("=\"") << m_stringBuffer[idx] << ("\"]");
+				}
 				mu::console() << _T("[ADDR: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.cb._pRawFun) << _T("]");
 				mu::console() << _T("[USERDATA: 0x") << std::hex << reinterpret_cast<void*>(m_vRPN[i].Fun.cb._pUserData) << _T("]");
 				mu::console() << _T("\n");

--- a/src/muParserCallback.cpp
+++ b/src/muParserCallback.cpp
@@ -765,15 +765,18 @@ namespace mu
 		if (this == &ref)
 			return;
 
-		if (m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA) {
+		void* newFun = nullptr;
+		if (ref.m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
+			newFun = new CbWithUserData(*reinterpret_cast<CbWithUserData*>(ref.m_pFun));
+
+		if (m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
 			delete reinterpret_cast<CbWithUserData*>(m_pFun);
-			m_pFun = nullptr;
-		}
 
 		if (ref.m_iArgc & CALLBACK_INTERNAL_WITH_USER_DATA)
-			m_pFun = new CbWithUserData(*reinterpret_cast<CbWithUserData*>(ref.m_pFun));
+			m_pFun = newFun;
 		else
 			m_pFun = ref.m_pFun;
+
 		m_iArgc = ref.m_iArgc;
 		m_bAllowOpti = ref.m_bAllowOpti;
 		m_iCode = ref.m_iCode;

--- a/src/muParserDLL.cpp
+++ b/src/muParserDLL.cpp
@@ -81,7 +81,6 @@
 
 typedef mu::ParserBase::exception_type muError_t;
 typedef mu::ParserBase muParser_t;
-int g_nBulkSize;
 
 
 class ParserTag
@@ -114,7 +113,7 @@ private:
 	int m_nParserType;
 };
 
-static muChar_t s_tmpOutBuf[2048];
+static thread_local muChar_t s_tmpOutBuf[2048];
 
 template <typename T>
 constexpr std::size_t count_of(const T& array) 
@@ -195,10 +194,8 @@ API_EXPORT(muParserHandle_t) mupCreate(int nBaseType)
 /** \brief Release the parser instance related with a parser handle. */
 API_EXPORT(void) mupRelease(muParserHandle_t a_hParser)
 {
-	MU_TRY
-		ParserTag* p = static_cast<ParserTag*>(a_hParser);
-		delete p;
-	MU_CATCH
+	ParserTag* p = static_cast<ParserTag*>(a_hParser);
+	delete p;
 }
 
 
@@ -907,22 +904,28 @@ API_EXPORT(void) mupDefineInfixOprt(muParserHandle_t a_hParser, const muChar_t* 
 // Define character sets for identifiers
 API_EXPORT(void) mupDefineNameChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset)
 {
-	muParser_t* const p(AsParser(a_hParser));
-	p->DefineNameChars(a_szCharset);
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineNameChars(a_szCharset);
+	MU_CATCH
 }
 
 
 API_EXPORT(void) mupDefineOprtChars(muParserHandle_t a_hParser,	const muChar_t* a_szCharset)
 {
-	muParser_t* const p(AsParser(a_hParser));
-	p->DefineOprtChars(a_szCharset);
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineOprtChars(a_szCharset);
+	MU_CATCH
 }
 
 
 API_EXPORT(void) mupDefineInfixOprtChars(muParserHandle_t a_hParser, const muChar_t* a_szCharset)
 {
-	muParser_t* const p(AsParser(a_hParser));
-	p->DefineInfixOprtChars(a_szCharset);
+	MU_TRY
+		muParser_t* const p(AsParser(a_hParser));
+		p->DefineInfixOprtChars(a_szCharset);
+	MU_CATCH
 }
 
 
@@ -962,7 +965,7 @@ API_EXPORT(void) mupGetVar(muParserHandle_t a_hParser, unsigned a_iVar, const mu
 {
 	// A static buffer is needed for the name since i can't return the
 	// pointer from the map.
-	static muChar_t  szName[1024];
+	static thread_local muChar_t  szName[1024];
 
 	MU_TRY
 		muParser_t* const p(AsParser(a_hParser));
@@ -1035,7 +1038,7 @@ API_EXPORT(void) mupGetExprVar(muParserHandle_t a_hParser, unsigned a_iVar, cons
 {
 	// A static buffer is needed for the name since i can't return the
 	// pointer from the map.
-	static muChar_t  szName[1024];
+	static thread_local muChar_t  szName[1024];
 
 	MU_TRY
 		muParser_t* const p(AsParser(a_hParser));
@@ -1130,7 +1133,7 @@ API_EXPORT(void) mupGetConst(muParserHandle_t a_hParser, unsigned a_iVar, const 
 {
 	// A static buffer is needed for the name since i can't return the
 	// pointer from the map.
-	static muChar_t szName[1024];
+	static thread_local muChar_t szName[1024];
 
 	MU_TRY
 		muParser_t* const p(AsParser(a_hParser));

--- a/src/muParserInt.cpp
+++ b/src/muParserInt.cpp
@@ -54,7 +54,11 @@ namespace mu
 		if (divisor == 0)
 			throw ParserError(ecDIV_BY_ZERO);
 
-		return Round(v1) / divisor;
+		int dividend = Round(v1);
+		if (dividend == INT_MIN && divisor == -1)
+			throw ParserError(ecDOMAIN_ERROR);
+
+		return dividend / divisor;
 	}
 
 	value_type ParserInt::Mod(value_type v1, value_type v2) 
@@ -63,7 +67,11 @@ namespace mu
 		if (divisor == 0)
 			throw ParserError(ecDIV_BY_ZERO);
 
-		return Round(v1) % divisor;
+		int dividend = Round(v1);
+		if (dividend == INT_MIN && divisor == -1)
+			throw ParserError(ecDOMAIN_ERROR);
+
+		return dividend % divisor;
 	}
 	
 	value_type ParserInt::Shr(value_type v1, value_type v2) 
@@ -72,7 +80,7 @@ namespace mu
 		if (shift < 0 || shift >= (int)(sizeof(int) * 8))
 			throw ParserError(ecDOMAIN_ERROR);
 
-		return Round(v1) >> shift;
+		return (int)((unsigned)Round(v1) >> shift);
 	}
 
 	value_type ParserInt::Shl(value_type v1, value_type v2) 
@@ -81,7 +89,7 @@ namespace mu
 		if (shift < 0 || shift >= (int)(sizeof(int) * 8))
 			throw ParserError(ecDOMAIN_ERROR);
 
-		return Round(v1) << shift;
+		return (int)((unsigned)Round(v1) << shift);
 	}
 
 	value_type ParserInt::BitAnd(value_type v1, value_type v2) { return Round(v1) & Round(v2); }
@@ -153,6 +161,9 @@ namespace mu
 		std::size_t pos = buf.find_first_not_of(_T("0123456789"));
 
 		if (pos == std::string::npos)
+			pos = buf.length();
+
+		if (pos == 0)
 			return 0;
 
 		stringstream_type stream(buf.substr(0, pos));
@@ -198,7 +209,7 @@ namespace mu
 		nPos = ss.tellg();
 
 		if (nPos == (stringstream_type::pos_type)0)
-			return 1;
+			return 0;
 
 		*a_iPos += (int)(2 + nPos);
 		*a_fVal = (value_type)iVal;


### PR DESCRIPTION
Critical:
- Fix use-after-free in mupRelease by deleting outside MU_TRY/MU_CATCH

High:
- Add missing MU_TRY/MU_CATCH to mupDefineNameChars, mupDefineOprtChars, mupDefineInfixOprtChars to prevent exceptions crossing C ABI boundary
- Make s_tmpOutBuf, mupGetVar, mupGetExprVar, mupGetConst buffers thread_local to fix data races in multi-threaded usage
- Fix IsVal returning 0 for all-digit strings (npos not handled)
- Fix IsHexVal returning success when no hex digits follow "0x"
- Add null pointer checks for variable pointers in ParseCmdCodeShort

Medium:
- Fix AsciiDump bounds check to validate string buffer index, not bytecode loop index
- Skip constant folding when divisor is zero instead of producing inf
- Add INT_MIN / -1 overflow check in Div and Mod (undefined behavior)
- Cast to unsigned before shifting in Shr/Shl to avoid UB on negatives
- Check stIf/stElse non-empty before top() in Finalize to prevent crash on malformed bytecode

Low:
- Remove unused global variable g_nBulkSize
- Fix exception safety in ParserCallback::Assign by creating new object before deleting old one